### PR TITLE
chore: setup automated testing infrastructure

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -88,6 +88,7 @@ create_table_id() {
 #      can probably avoid this with escaping, etc., but it's not really critical
 #      since there's nothing special about its byte value to try to manually cover.
 #  2. Repeated characters would be ignored w/o affecting correctness.
+# TODO: Move the pre-split logic to the Java test using client APIs.
 create_table_with_random_splits() {
     BIGTABLE_PROJECT_ID=$1
     BIGTABLE_INSTANCE_ID=$2
@@ -140,6 +141,7 @@ run_load_test() {
     return $exit_code
 }
 
+# TODO: Delete all existing fuzz-test tables if there are old ones remaining.
 run_fuzz_tests() {
     SPARK_VERSION=$1
     echo "***Running Spark-Bigtable fuzz tests for Spark ${SPARK_VERSION}.***"
@@ -174,6 +176,7 @@ run_pyspark_test() {
     BASE_SCRIPT="spark-bigtable_2.12/test-pyspark/test_base.py"
     # Download Apache Spark on the machine from a GCS bucket, new versions
     # must be manually uploaded to the bucket first.
+    # TODO: Move this logic to an env setup script/Java code for easier reproduction.
     gsutil -q cp "gs://bigtable-spark-test-resources/spark-files/${SPARK_BIN_NAME}.tgz" .
     tar xzf ${SPARK_BIN_NAME}.tgz
     PYSPARK_TABLE_ID=$(create_table_id "pyspark")

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+## Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
+
+# include common functions
+source ${scriptDir}/common.sh
+
+# Print out Maven & Java version
+mvn -version
+echo ${JOB_TYPE}
+
+# attempt to install 3 times with exponential backoff (starting with 10 seconds)
+retry_with_backoff 3 10 \
+  mvn install -B -V -ntp \
+    -DskipTests=true \
+    -Dclirr.skip=true \
+    -Denforcer.skip=true \
+    -Dmaven.javadoc.skip=true \
+    -Dgcloud.download.skip=true \
+    -T 1C
+
+# if GOOGLE_APPLICATION_CREDENTIALS is specified as a relative path, prepend Kokoro root directory onto it
+if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
+    export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
+fi
+
+RETURN_CODE=0
+set +e
+
+echo "Installing the cbt CLI command."
+apt install -y google-cloud-sdk-cbt
+
+run_unit_tests() {
+    echo "***Running connector's unit tests.***"
+    CONNECTOR_MODULE="spark-bigtable_2.12"
+    mvn -pl ${CONNECTOR_MODULE} -am  \
+        test -B -ntp -Dclirr.skip=true -Denforcer.skip=true -Dcheckstyle.skip
+    return $?
+}
+
+run_bigtable_spark_tests() {
+    SPARK_VERSION=$1
+    MAVEN_PROFILES=$2
+    echo "***Running Spark-Bigtable tests for Spark ${SPARK_VERSION} and profile(s) ${MAVEN_PROFILES}.***"
+    BIGTABLE_SPARK_IT_MODULE="spark-bigtable_2.12-it"
+    mvn -pl ${BIGTABLE_SPARK_IT_MODULE} \
+        failsafe:integration-test failsafe:verify \
+        -B -ntp -Dclirr.skip=true -Denforcer.skip=true -Dcheckstyle.skip \
+        -Dspark.version=${SPARK_VERSION} \
+        -DbigtableProjectId=${BIGTABLE_PROJECT_ID} \
+        -DbigtableInstanceId=${BIGTABLE_INSTANCE_ID} \
+        -P ${MAVEN_PROFILES}
+    return $?
+}
+
+get_bigtable_spark_jar() {
+    # This makes the script independent of the connector's version and
+    # ignores the source code JAR.
+    echo $(ls spark-bigtable_2.12/target/spark-bigtable_2.12-* | grep -v sources)
+}
+
+create_table_id() {
+    TEST_TYPE=$1
+    # Generate a random id with the 'cbt-TEST_TYPE-1682536895-138fa' format.
+    echo "cbt-${TEST_TYPE}-$(date +%s)-$(echo $RANDOM | md5sum | head -c 5)"
+}
+
+# Create a table with pre-splits at random bytes. Some caveats:
+#  1. character \054 (comma) gets ignored because ',' is also the delimiter. we
+#      can probably avoid this with escaping, etc., but it's not really critical
+#      since there's nothing special about its byte value to try to manually cover.
+#  2. Repeated characters would be ignored w/o affecting correctness.
+create_table_with_random_splits() {
+    BIGTABLE_PROJECT_ID=$1
+    BIGTABLE_INSTANCE_ID=$2
+    TABLE_ID=$3
+
+    num_of_splits=$(($RANDOM % 13 + 3))  # Random number of splits, between 3 and 15
+    ascii_code_list=""
+    split_points=""
+    for _ in $(seq 1 $num_of_splits); do
+        random_ascii_code=$(($RANDOM % 256))  # Range 0-255 for full ASCII
+        ascii_code_list+="$random_ascii_code,"
+        random_char=$(printf "\\$(printf '%03o' "$random_ascii_code")")
+        if [[ -n $split_points ]]; then  # Add comma before, except for the first character
+            split_points+=","
+        fi
+        split_points+="$random_char"
+    done
+    echo "Creating table $TABLE_ID with $num_of_splits split points $ascii_code_list"
+    cbt -project="${BIGTABLE_PROJECT_ID}" -instance="${BIGTABLE_INSTANCE_ID}" \
+            createtable "${TABLE_ID}" "families=col_family" splits="$split_points"
+}
+
+delete_table() {
+    BIGTABLE_PROJECT_ID=$1
+    BIGTABLE_INSTANCE_ID=$2
+    TABLE_ID=$3
+    cbt -project=${BIGTABLE_PROJECT_ID} -instance=${BIGTABLE_INSTANCE_ID} \
+        deletetable  ${TABLE_ID}
+    if [[ $? != 0 ]]; then echo "Could not delete table for PySpark test."; fi
+}
+
+run_load_test() {
+    echo "***Running Load test.***"
+    BIGTABLE_SPARK_JAR=$(get_bigtable_spark_jar)
+    TEST_SCRIPT="spark-bigtable_2.12/test-pyspark/load_test.py"
+    BASE_SCRIPT="spark-bigtable_2.12/test-pyspark/test_base.py"
+    TABLE_ID=$(create_table_id "load")
+    gcloud dataproc jobs submit pyspark \
+        --cluster=${DATAPROC_CLUSTER_NAME} \
+        --region=${DATAPROC_CLUSTER_REGION} \
+        --jars=${BIGTABLE_SPARK_JAR} \
+        ${TEST_SCRIPT} \
+        --py-files=${BASE_SCRIPT} \
+        -- \
+        --bigtableProjectId=${BIGTABLE_PROJECT_ID} \
+        --bigtableInstanceId=${BIGTABLE_INSTANCE_ID} \
+        --bigtableTableId=${TABLE_ID}
+    exit_code=$?
+    delete_table ${BIGTABLE_PROJECT_ID} ${BIGTABLE_INSTANCE_ID} ${TABLE_ID}
+    return $exit_code
+}
+
+run_fuzz_tests() {
+    SPARK_VERSION=$1
+    echo "***Running Spark-Bigtable fuzz tests for Spark ${SPARK_VERSION}.***"
+    TABLE_ID=$(create_table_id "fuzz")
+    create_table_with_random_splits \
+      "${BIGTABLE_PROJECT_ID}" "${BIGTABLE_INSTANCE_ID}" "$TABLE_ID"
+    BIGTABLE_SPARK_IT_MODULE="spark-bigtable_2.12-it"
+    mvn -pl ${BIGTABLE_SPARK_IT_MODULE} \
+        failsafe:integration-test failsafe:verify \
+        -B -ntp -Dclirr.skip=true -Denforcer.skip=true -Dcheckstyle.skip \
+        -Dspark.version="${SPARK_VERSION}" \
+        -DbigtableProjectId="${BIGTABLE_PROJECT_ID}" \
+        -DbigtableInstanceId="${BIGTABLE_INSTANCE_ID}" \
+        -DbigtableTableId="${TABLE_ID}" \
+        -P fuzz
+    exit_code=$?
+    delete_table "${BIGTABLE_PROJECT_ID}" "${BIGTABLE_INSTANCE_ID}" "${TABLE_ID}"
+    return $exit_code
+}
+
+run_pyspark_test() {
+    SPARK_VERSION=$1
+    HADOOP_VERSION=$2
+    # TODO: Install Python 3.7 on Kokoro machines to enable PySpark 2.4.8 tests
+    #   without running into the "TypeError: an integer is required" issue.
+    if [[ ${SPARK_VERSION} == "2.4.8" ]]; then return; fi
+
+    echo "***Running the PySpark test for Spark ${SPARK_VERSION}.***"
+    SPARK_BIN_NAME="spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}"
+    BIGTABLE_SPARK_JAR=$(get_bigtable_spark_jar)
+    PYSPARK_TEST_SCRIPT="spark-bigtable_2.12/test-pyspark/read_and_write_test.py"
+    BASE_SCRIPT="spark-bigtable_2.12/test-pyspark/test_base.py"
+    # Download Apache Spark on the machine from a GCS bucket, new versions
+    # must be manually uploaded to the bucket first.
+    gsutil -q cp "gs://bigtable-spark-test-resources/spark-files/${SPARK_BIN_NAME}.tgz" .
+    tar xzf ${SPARK_BIN_NAME}.tgz
+    PYSPARK_TABLE_ID=$(create_table_id "pyspark")
+    ./${SPARK_BIN_NAME}/bin/spark-submit \
+        --packages=org.slf4j:slf4j-reload4j:1.7.36 \
+        --jars ${BIGTABLE_SPARK_JAR} \
+        --py-files=${BASE_SCRIPT} \
+        ${PYSPARK_TEST_SCRIPT} \
+        --bigtableProjectId=${BIGTABLE_PROJECT_ID} \
+        --bigtableInstanceId=${BIGTABLE_INSTANCE_ID} \
+        --bigtableTableId=${PYSPARK_TABLE_ID}
+    exit_code=$?
+    delete_table ${BIGTABLE_PROJECT_ID} ${BIGTABLE_INSTANCE_ID} ${PYSPARK_TABLE_ID}
+    return $exit_code
+}
+
+case ${JOB_TYPE} in
+presubmit)
+    run_bigtable_spark_tests "3.1.3" "integration"
+    RETURN_CODE=$?
+    run_pyspark_test "3.1.3" "3.2"
+    RETURN_CODE=$(($RETURN_CODE || $?))
+    run_unit_tests
+    RETURN_CODE=$(($RETURN_CODE || $?))
+    ;;
+all_versions)
+    RETURN_CODE=0
+    for SPARK_VERSION in "2.4.8" "3.1.3" "3.3.0" "3.4.2"
+    do
+        run_bigtable_spark_tests ${SPARK_VERSION} "integration"
+        RETURN_CODE=$(($RETURN_CODE || $?))
+    done
+    for SPARK_HADOOP_VERSIONS in "2.4.8 2.7" "3.1.3 3.2" "3.3.0 3" "3.4.2 3"
+    do
+        run_pyspark_test ${SPARK_HADOOP_VERSIONS}
+        RETURN_CODE=$(($RETURN_CODE || $?))
+    done
+    run_unit_tests
+    RETURN_CODE=$(($RETURN_CODE || $?))
+    ;;
+fuzz)
+    run_fuzz_tests "3.1.3"
+    RETURN_CODE=$?
+    ;;
+long_running)
+    run_bigtable_spark_tests "3.1.3" "long-running"
+    RETURN_CODE=$?
+    ;;
+load)
+    run_load_test
+    RETURN_CODE=$?
+    ;;
+*)
+    ;;
+esac
+
+# fix output location of logs
+bash .kokoro/coerce_logs.sh
+
+echo "exiting with ${RETURN_CODE}"
+exit ${RETURN_CODE}

--- a/.kokoro/coerce_logs.sh
+++ b/.kokoro/coerce_logs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script finds and moves sponge logs so that they can be found by placer
+# and are not flagged as flaky by sponge.
+
+set -eo pipefail
+
+## Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
+
+job=$(basename ${KOKORO_JOB_NAME})
+
+echo "coercing sponge logs..."
+for xml in `find . -name *-sponge_log.xml`
+do
+  class=$(basename ${xml} | cut -d- -f2)
+  dir=$(dirname ${xml})/${job}/${class}
+  text=$(dirname ${xml})/${class}-sponge_log.txt
+  mkdir -p ${dir}
+  mv ${xml} ${dir}/sponge_log.xml
+  mv ${text} ${dir}/sponge_log.txt
+done

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -1,0 +1,13 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download trampoline resources. These will be in ${KOKORO_GFILE_DIR}
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# All builds use the trampoline script to run in docker.
+build_file: "spark-bigtable-connector/.kokoro/trampoline.sh"
+
+# Tell the trampoline which build file to use.
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/spark-bigtable-connector/.kokoro/build.sh"
+}

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function retry_with_backoff {
+    attempts_left=$1
+    sleep_seconds=$2
+    shift 2
+    command=$@
+
+
+    # store current flag state
+    flags=$-
+    
+    # allow a failures to continue
+    set +e
+    ${command}
+    exit_code=$?
+
+    # restore "e" flag
+    if [[ ${flags} =~ e ]]
+    then set -e
+    else set +e
+    fi
+
+    if [[ $exit_code == 0 ]]
+    then
+        return 0
+    fi
+
+    # failure
+    if [[ ${attempts_left} > 0 ]]
+    then
+        echo "failure (${exit_code}), sleeping ${sleep_seconds}..."
+        sleep ${sleep_seconds}
+        new_attempts=$((${attempts_left} - 1))
+        new_sleep=$((${sleep_seconds} * 2))
+        retry_with_backoff ${new_attempts} ${new_sleep} ${command}
+    fi
+
+    return $exit_code
+}
+
+## Helper functionss
+function now() { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n'; }
+function msg() { println "$*" >&2; }
+function println() { printf '%s\n' "$(now) $*"; }
+
+## Helper comment to trigger updated repo dependency release

--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+shopt -s nullglob
+
+## Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
+
+# include common functions
+source ${scriptDir}/common.sh
+
+# Print out Java
+java -version
+echo $JOB_TYPE
+
+function determineMavenOpts() {
+  local javaVersion=$(
+    # filter down to the version line, then pull out the version between quotes,
+    # then trim the version number down to its minimal number (removing any
+    # update or suffix number).
+    java -version 2>&1 | grep "version" \
+      | sed -E 's/^.*"(.*?)".*$/\1/g' \
+      | sed -E 's/^(1\.[0-9]\.0).*$/\1/g'
+  )
+
+  if [[ $javaVersion == 17* ]]
+    then
+      # MaxPermSize is no longer supported as of jdk 17
+      echo -n "-Xmx1024m"
+  else
+      echo -n "-Xmx1024m -XX:MaxPermSize=128m"
+  fi
+}
+
+export MAVEN_OPTS=$(determineMavenOpts)
+
+# this should run maven enforcer
+retry_with_backoff 3 10 \
+  mvn install -B -V -ntp \
+    -DskipTests=true \
+    -Dmaven.javadoc.skip=true \
+    -Dclirr.skip=true
+
+mvn -B dependency:analyze -DfailOnWarning=true

--- a/.kokoro/periodic/all-versions.cfg
+++ b/.kokoro/periodic/all-versions.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "all_versions"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}

--- a/.kokoro/periodic/common.cfg
+++ b/.kokoro/periodic/common.cfg
@@ -1,0 +1,21 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+    regex: "**/*sponge_log.txt"
+  }
+}
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "spark-bigtable-connector/.kokoro/trampoline.sh"
+
+# TODO: Change 'git' to 'github' when releasing on GitHub.
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/spark-bigtable-connector/.kokoro/build.sh"
+}

--- a/.kokoro/periodic/fuzz.cfg
+++ b/.kokoro/periodic/fuzz.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "fuzz"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}

--- a/.kokoro/periodic/load.cfg
+++ b/.kokoro/periodic/load.cfg
@@ -1,0 +1,34 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "load"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}
+
+env_vars: {
+  key: "DATAPROC_CLUSTER_NAME"
+  value: "bigtable-spark-connector-v2-0"
+}
+
+env_vars: {
+  key: "DATAPROC_CLUSTER_REGION"
+  value: "us-central1"
+}
+
+timeout_mins: 1200

--- a/.kokoro/periodic/long-running.cfg
+++ b/.kokoro/periodic/long-running.cfg
@@ -1,0 +1,24 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "long_running"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}
+
+timeout_mins: 1200

--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function now { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n' ;}
+function msg { println "$*" >&2 ;}
+function println { printf '%s\n' "$(now) $*" ;}
+
+
+# Populates requested secrets set in SECRET_MANAGER_KEYS from service account:
+# kokoro-trampoline@cloud-devrel-kokoro-resources.iam.gserviceaccount.com
+SECRET_LOCATION="${KOKORO_GFILE_DIR}/secret_manager"
+msg "Creating folder on disk for secrets: ${SECRET_LOCATION}"
+mkdir -p ${SECRET_LOCATION}
+for key in $(echo ${SECRET_MANAGER_KEYS} | sed "s/,/ /g")
+do
+  msg "Retrieving secret ${key}"
+  docker run --entrypoint=gcloud \
+    --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
+    gcr.io/google.com/cloudsdktool/cloud-sdk \
+    secrets versions access latest \
+    --project cloud-devrel-kokoro-resources \
+    --secret ${key} > \
+    "${SECRET_LOCATION}/${key}"
+  if [[ $? == 0 ]]; then
+    msg "Secret written to ${SECRET_LOCATION}/${key}"
+  else
+    msg "Error retrieving secret ${key}"
+  fi
+done

--- a/.kokoro/presubmit/codestyle/build.sh
+++ b/.kokoro/presubmit/codestyle/build.sh
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+# Display commands being run.
+# WARNING: please only enable 'set -x' if necessary for debugging, and be very
+#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
+#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
+#  the credentials being printed in build logs.
+#  Additionally, recursive invocation with credentials as command-line
+#  parameters, will print the full command, with credentials, in the build logs.
+set -x
+
+cd ${KOKORO_ARTIFACTS_DIR}/github/spark-bigtable-connector
+
+find spark-bigtable_2.12 spark-bigtable_2.12-it -name "*.java" -type f -exec java -jar  ${KOKORO_GFILE_DIR}/google-java-format-1.7-all-deps.jar --set-exit-if-changed -n {} +

--- a/.kokoro/presubmit/codestyle/codestyle.cfg
+++ b/.kokoro/presubmit/codestyle/codestyle.cfg
@@ -1,0 +1,10 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+
+# Location of the bash script. Should have value <git_on_borg_scm.name>/<path_from_repository_root>.
+# git_on_borg_scm.name is specified in the job configuration (next section).
+build_file: "spark-bigtable-connector/.kokoro/presubmit/codestyle/build.sh"
+
+# Kokoro will download everything under repo and store it under ${KOKORO_GFILE_DIR}/<contents of repo>
+gfile_resources: "/x20/teams/cloud-bigtable/google-java-format"
+

--- a/.kokoro/presubmit/common.cfg
+++ b/.kokoro/presubmit/common.cfg
@@ -1,0 +1,35 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+    regex: "**/*sponge_log.txt"
+  }
+}
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "spark-bigtable-connector/.kokoro/trampoline.sh"
+
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/spark-bigtable-connector/.kokoro/build.sh"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "test"
+}
+
+# TODO: Uncomment when needing to use keystore.
+# before_action {
+#   fetch_keystore {
+#     keystore_resource {
+#       keystore_config_id: 73713
+#       keyname: "dpebot_codecov_token"
+#     }
+#   }
+# }

--- a/.kokoro/presubmit/java11.cfg
+++ b/.kokoro/presubmit/java11.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "presubmit"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eo pipefail
+# Always run the cleanup script, regardless of the success of bouncing into
+# the container.
+
+# TODO: Uncomment after fixing the
+# "chmod: changing permissions of [...] Operation not permitted" issue.
+# function cleanup() {
+#     chmod +x ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
+#     ${KOKORO_GFILE_DIR}/trampoline_cleanup.sh
+#     echo "cleanup";
+# }
+# trap cleanup EXIT
+
+# Install Docker on the cbt-iw machine in order to use the Trampoline script.
+sudo apt install -y apt-transport-https ca-certificates curl software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu `lsb_release -cs` test"
+sudo apt update
+sudo apt install -y docker-ce
+
+$(dirname $0)/populate-secrets.sh # Secret Manager secrets.
+python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+## 0.1.0 - 2024-05-01
+
+* Initial release

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This connector allows writing Spark SQL DataFrames
 into [Google Bigtable](https://cloud.google.com/bigtable) and reading tables
 from Bigtable. It uses
-the[Spark SQL Data Source API V1](https://spark.apache.org/docs/latest/sql-data-sources.html)
+the [Spark SQL Data Source API V1](https://spark.apache.org/docs/latest/sql-data-sources.html)
 to connect to Bigtable.
 
 ## Quickstart
@@ -25,7 +25,6 @@ the `--jars` flag to pass the GCS address of the connector when submitting it.
 For Maven, you can add the following snippet to your `pom.xml` file:
 
 ```xml
-
 <dependency>
   <groupId>com.google.cloud.spark.bigtable</groupId>
   <artifactId>spark-bigtable_2.12</artifactId>

--- a/spark-bigtable_2.12-it/pom.xml
+++ b/spark-bigtable_2.12-it/pom.xml
@@ -97,6 +97,18 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>integration</id>


### PR DESCRIPTION
Create the scripts for the automated testing infrastructure.

This also creates the changelog file and excludes the integration test module (`spark-bigtable_2.12-it`) from being deployed on Maven.