### PR TITLE
chore: add a next_version_flag.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <groupId>com.google.cloud.spark.bigtable</groupId>
   <artifactId>spark-bigtable-connector</artifactId>
   <packaging>pom</packaging>
-  <version>0.1.1</version>
+  <version>0.1.1</version>  <!-- ${NEXT_VERSION_FLAG} -->
   <name>Spark Bigtable Connector Build Parent</name>
   <description>Parent project for all the Spark Bigtable Connector artifacts</description>
   <url>https://github.com/GoogleCloudDataproc/spark-bigtable-connector</url>

--- a/spark-bigtable_2.12-it/pom.xml
+++ b/spark-bigtable_2.12-it/pom.xml
@@ -21,14 +21,14 @@
   <parent>
     <groupId>com.google.cloud.spark.bigtable</groupId>
     <artifactId>spark-bigtable-connector</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.1</version>  <!-- ${NEXT_VERSION_FLAG} -->
     <relativePath>../</relativePath>
   </parent>
 
   <groupId>com.google.cloud.spark.bigtable</groupId>
   <artifactId>spark-bigtable_2.12-it</artifactId>
   <name>Google Bigtable - Spark Connector Integration Tests</name>
-  <version>0.1.1</version>
+  <version>0.1.1</version>  <!-- ${NEXT_VERSION_FLAG} -->
 
   <dependencies>
     <dependency>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.google.cloud.spark.bigtable</groupId>
       <artifactId>spark-bigtable_2.12</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.1</version>  <!-- ${NEXT_VERSION_FLAG} -->
     </dependency>
 
     <dependency>

--- a/spark-bigtable_2.12/pom.xml
+++ b/spark-bigtable_2.12/pom.xml
@@ -21,14 +21,14 @@
   <parent>
     <groupId>com.google.cloud.spark.bigtable</groupId>
     <artifactId>spark-bigtable-connector</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.1</version>  <!-- ${NEXT_VERSION_FLAG} -->
     <relativePath>../</relativePath>
   </parent>
 
   <groupId>com.google.cloud.spark.bigtable</groupId>
   <artifactId>spark-bigtable_2.12</artifactId>
   <name>Google Bigtable - Apache Spark Connector</name>
-  <version>0.1.1</version>
+  <version>0.1.1</version>  <!-- ${NEXT_VERSION_FLAG} -->
 
   <dependencies>
     <dependency>

--- a/spark-bigtable_2.12/src/main/scala/com/google/cloud/spark/bigtable/BigtableDefaultSource.scala
+++ b/spark-bigtable_2.12/src/main/scala/com/google/cloud/spark/bigtable/BigtableDefaultSource.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, Row => SparkRow}
 import org.apache.yetus.audience.InterfaceAudience
 
 object VersionInformation {
-  val CONNECTOR_VERSION = "0.1.1"
+  val CONNECTOR_VERSION = "0.1.1"  // ${NEXT_VERSION_FLAG}
   val DATA_SOURCE_VERSION = "V1"
   val scalaVersion = util.Properties.versionNumberString
   // This remains unset only in unit tests where sqlContext is null.


### PR DESCRIPTION
This allows updating connector version automatically during releases.