### PR TITLE
test: deflake the open lineage test.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,20 +2,21 @@
 
 ## Next
 
+* PR #44: feat: Add OpenLineage reporting support.
 * PR #42: feat: Add RDD support to the connector.
 
 ## 0.2.1 - 2024-08-21
 
-* PR #36: Update Bigtable Java client version to 2.42.0.
-* PR #35: Add testing for Data Boost. 
+* PR #36: chore: Update Bigtable Java client version to 2.42.0.
+* PR #35: test: Add testing for Data Boost. 
 
 ## 0.2.0 - 2024-07-29
 
-* PR #33: Add support for more primitive types, i.e., Int, Float, etc.
+* PR #33: feat: Add support for more primitive types, i.e., Int, Float, etc.
 
 ## 0.1.1 - 2024-06-11
 
-* PR #10: Create a new profile for the release
+* PR #10: ci: Create a new profile for the release
 
 ## 0.1.0 - 2024-05-01
 

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/AbstractTestBase.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/AbstractTestBase.java
@@ -82,9 +82,17 @@ public abstract class AbstractTestBase {
     return SparkSession.builder().master("local").config("spark.ui.enabled", "false").getOrCreate();
   }
 
+  static void stopSparkSession(SparkSession sparkSession) {
+    sparkSession.stop();
+  }
+
   static JavaSparkContext createJavaSparkContext() {
     spark = createSparkSession();
     return new JavaSparkContext(spark.sparkContext());
+  }
+
+  static void stopJavaSparkContext(JavaSparkContext javaSparkContext) {
+    javaSparkContext.stop();
   }
 
   static void setBigtableProperties() throws Exception {

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/DataBoostIntegrationTest.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/DataBoostIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import junitparams.JUnitParamsRunner;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +38,11 @@ public class DataBoostIntegrationTest extends AbstractTestBase {
   public static void initialSetup() throws Exception {
     spark = createSparkSession();
     setBigtableProperties();
+  }
+
+  @AfterClass
+  public static void cleanup() throws Exception {
+    stopSparkSession(spark);
   }
 
   @Test

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/ErrorHandlingIntegrationTest.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/ErrorHandlingIntegrationTest.java
@@ -38,7 +38,9 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -56,6 +58,11 @@ public class ErrorHandlingIntegrationTest extends AbstractTestBase {
 
   private String FAKE_ERROR_MESSAGE = "Fake error message";
 
+  @BeforeClass
+  public static void initialBeforeClassSetup() throws Exception {
+    spark = createSparkSession();
+  }
+
   @Before
   public void initialSetup() throws Exception {
     fakeGenericDataService = new FakeGenericDataService();
@@ -68,8 +75,12 @@ public class ErrorHandlingIntegrationTest extends AbstractTestBase {
     LOG.info("Bigtable mock server started on port " + server.getPort());
     emulatorPort = Integer.toString(server.getPort());
 
-    spark = createSparkSession();
     setBigtableProperties();
+  }
+
+  @AfterClass
+  public static void cleanup() throws Exception {
+    stopSparkSession(spark);
   }
 
   @After

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/FilterPushDownFuzzTest.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/FilterPushDownFuzzTest.java
@@ -67,6 +67,7 @@ public class FilterPushDownFuzzTest extends AbstractTestBase {
   @AfterClass
   public static void cleanup() throws Exception {
     adminClient.close();
+    stopSparkSession(spark);
   }
 
   @Test

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/OpenLineageIntegrationTest.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/OpenLineageIntegrationTest.java
@@ -30,6 +30,7 @@ public class OpenLineageIntegrationTest extends AbstractTestBase {
 
   @BeforeClass
   public static void initialSetup() throws Exception {
+    System.out.println("*debugging* lineage test");
     spark = createSparkSessionWithOL();
     setBigtableProperties();
 
@@ -128,10 +129,12 @@ public class OpenLineageIntegrationTest extends AbstractTestBase {
 
   private List<JsonObject> parseEventLog(File file) throws Exception {
     List<JsonObject> eventList;
+    System.out.println("*debugging* in parseEvent");
     try (Scanner scanner = new Scanner(file)) {
       eventList = new ArrayList<>();
       while (scanner.hasNextLine()) {
         String line = scanner.nextLine();
+        System.out.println("*debugging* line = " + line);
         JsonObject event = JsonParser.parseString(line).getAsJsonObject();
         if (!event.getAsJsonArray("inputs").isEmpty()
             && !event.getAsJsonArray("outputs").isEmpty()) {

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/OpenLineageIntegrationTest.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/OpenLineageIntegrationTest.java
@@ -30,7 +30,6 @@ public class OpenLineageIntegrationTest extends AbstractTestBase {
 
   @BeforeClass
   public static void initialSetup() throws Exception {
-    System.out.println("*debugging* lineage test");
     spark = createSparkSessionWithOL();
     setBigtableProperties();
 
@@ -83,7 +82,8 @@ public class OpenLineageIntegrationTest extends AbstractTestBase {
       String outputCatalog = parameterizeCatalog(outputCatalogTemplate, outputTable);
       writeDataframeToBigtable(outputDf, outputCatalog, false);
 
-      // Ensure OpenLineage events have sufficient time to propagate to avoid incomplete or missing event data.
+      // Ensure OpenLineage events have sufficient time to propagate to avoid incomplete or missing
+      // event data.
       Dataset<Row> outputReadDf = readDataframeFromBigtable(spark, outputCatalog);
       assertDataFramesEqual(outputReadDf, outputDf);
 
@@ -129,12 +129,10 @@ public class OpenLineageIntegrationTest extends AbstractTestBase {
 
   private List<JsonObject> parseEventLog(File file) throws Exception {
     List<JsonObject> eventList;
-    System.out.println("*debugging* in parseEvent");
     try (Scanner scanner = new Scanner(file)) {
       eventList = new ArrayList<>();
       while (scanner.hasNextLine()) {
         String line = scanner.nextLine();
-        System.out.println("*debugging* line = " + line);
         JsonObject event = JsonParser.parseString(line).getAsJsonObject();
         if (!event.getAsJsonArray("inputs").isEmpty()
             && !event.getAsJsonArray("outputs").isEmpty()) {

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/RDDReadWriteIntegrationTests.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/RDDReadWriteIntegrationTests.java
@@ -69,6 +69,7 @@ public class RDDReadWriteIntegrationTests extends AbstractTestBase {
   @AfterClass
   public static void cleanup() throws Exception {
     adminClient.close();
+    stopJavaSparkContext(javaSparkContext);
   }
 
   @Test

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/ReadWriteIntegrationTest.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/ReadWriteIntegrationTest.java
@@ -63,6 +63,7 @@ public class ReadWriteIntegrationTest extends AbstractTestBase {
   @AfterClass
   public static void cleanup() throws Exception {
     adminClient.close();
+    stopSparkSession(spark);
   }
 
   @Test

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/ReadWriteLongRunningTest.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/ReadWriteLongRunningTest.java
@@ -62,6 +62,7 @@ public class ReadWriteLongRunningTest extends AbstractTestBase {
   @AfterClass
   public static void cleanup() throws Exception {
     adminClient.close();
+    stopSparkSession(spark);
   }
 
   @Test

--- a/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/WriteFuzzTest.java
+++ b/spark-bigtable_2.12-it/src/test/java/com/google/cloud/spark/bigtable/WriteFuzzTest.java
@@ -72,6 +72,7 @@ public class WriteFuzzTest extends AbstractTestBase {
   @AfterClass
   public static void cleanup() throws Exception {
     adminClient.close();
+    stopSparkSession(spark);
   }
 
   @Test


### PR DESCRIPTION
Here we make sure that the SparkSession objects are closed at the end of each type of test to avoid interference between different test types, which was causing flakiness in the new OpenLineage test.