### PR TITLE
Bigtable table join push down implementation

### DIFF
--- a/examples/scala-sbt/src/main/scala/spark/bigtable/example/JoinPushDown.scala
+++ b/examples/scala-sbt/src/main/scala/spark/bigtable/example/JoinPushDown.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spark.bigtable.example
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.functions.col
+import java.nio.ByteBuffer
+
+object JoinPushDown extends App {
+  val (projectId, instanceId, tableName, createNewTable) = parse(args)
+
+  implicit lazy val spark = SparkSession.builder().getOrCreate()
+
+  val doubleToBinaryUdf = udf((value: Double) => doubleToBinary(value))
+  val binaryToDoubleUdf =
+    udf((binaryData: Array[Byte]) => binaryToDouble(binaryData))
+
+  val catalog =
+    s"""{
+       |"table":{"namespace":"default", "name":"$tableName", "tableCoder":"PrimitiveType"},
+       |"rowkey":"wordCol",
+       |"columns":{
+       |  "word":{"cf":"rowkey", "col":"wordCol", "type":"string"},
+       |  "count":{"cf":"example_family", "col":"countCol", "type":"long"},
+       |  "frequency_binary":{"cf":"example_family", "col":"frequencyCol", "type":"binary"}
+       |}
+       |}""".stripMargin
+
+  import spark.implicits._
+  val data = (0 to 999).map(i => ("word%3d".format(i), i, i / 1000.0))
+  val rdd = spark.sparkContext.parallelize(data)
+  val dfWithDouble = rdd.toDF("word", "count", "frequency_double")
+
+  println("Created the DataFrame:");
+  dfWithDouble.show()
+
+  val dfToWrite = dfWithDouble
+    .withColumn(
+      "frequency_binary",
+      doubleToBinaryUdf(dfWithDouble.col("frequency_double"))
+    )
+    .drop("frequency_double")
+
+  dfToWrite.write
+    .format("bigtable")
+    .option("catalog", catalog)
+    .option("spark.bigtable.project.id", projectId)
+    .option("spark.bigtable.instance.id", instanceId)
+    .option("spark.bigtable.create.new.table", createNewTable)
+    .save
+  println("DataFrame was written to Bigtable.")
+
+  val srcDf = dfToWrite.sample(100/1000).selectExpr("word", "count as src_count")
+
+  private val joinConfig: Map[String, String] = Map(
+    "spark.bigtable.project.id" -> projectId,
+    "spark.bigtable.instance.id" -> instanceId,
+    "catalog" -> catalog,
+    "join.type" -> "inner",
+    "columns.required" -> "word,src_count,count",
+    "partition.count" -> "10",
+    "batch.rowKeySize" -> "100",
+    "alias.name" -> "bt"
+  )
+
+  import com.google.cloud.spark.bigtable.join.BigtableJoinImplicit._
+  val resDf = srcDf.joinWithBigtable(joinConfig, "word", Seq("word"))
+
+  println("Pushed down join output:");
+  resDf.show()
+
+  def parse(args: Array[String]): (String, String, String, String) = {
+    import scala.util.Try
+    val projectId = Try(args(0)).getOrElse {
+      throw new IllegalArgumentException(
+        "Missing command-line argument: SPARK_BIGTABLE_PROJECT_ID"
+      )
+    }
+    val instanceId = Try(args(1)).getOrElse {
+      throw new IllegalArgumentException(
+        "Missing command-line argument: SPARK_BIGTABLE_INSTANCE_ID"
+      )
+    }
+    val tableName = Try(args(2)).getOrElse {
+      throw new IllegalArgumentException(
+        "Missing command-line argument: SPARK_BIGTABLE_TABLE_NAME"
+      )
+    }
+    val createNewTable = Try(args(3)).getOrElse {
+      "true"
+    }
+    (projectId, instanceId, tableName, createNewTable)
+  }
+
+  def doubleToBinary(value: Double): Array[Byte] = {
+    ByteBuffer.allocate(java.lang.Double.BYTES).putDouble(value).array()
+  }
+
+  def binaryToDouble(binaryData: Array[Byte]): Double = {
+    if (binaryData == null || binaryData.length == 0) {
+      Double.NaN
+    } else {
+      ByteBuffer.wrap(binaryData).getDouble()
+    }
+  }
+}

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/join/BigtableJoinImplicit.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/join/BigtableJoinImplicit.scala
@@ -1,0 +1,241 @@
+package com.google.cloud.spark.bigtable.join
+
+import com.google.cloud.spark.bigtable.datasources._
+import com.google.cloud.spark.bigtable.{Logging, ReadRowConversions, UserAgentInformation}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
+import com.google.api.gax.rpc.ServerStream
+import com.google.cloud.bigtable.data.v2.models.{Query, TableId, Row => BigtableRow}
+import com.google.protobuf.ByteString
+
+object BigtableJoinImplicit extends Serializable with Logging {
+
+  implicit class RichDataFrame(leftDf: DataFrame) extends Serializable with Logging {
+    private val JOIN_TYPE = "join.type"
+    private val COLUMNS_REQUIRED = "columns.required"
+    private val PARTITION_COUNT = "partition.count"
+    private val BATCH_ROWKEY_SIZE = "batch.rowKeySize"
+    private val DEFAULT_JOIN_TYPE = "inner"
+    private val DEFAULT_BATCH_SIZE = "25000"
+    private val RANGE_PARTITION_ENABLED = "range.partition.enabled"
+    private val DEFAULT_RANGE_PARTITION_ENABLED = "true"
+    private val ALIAS_NAME = "alias.name"
+    private val DEFAULT_ALIAS_NAME = ""
+    private val LEFT_JOIN = "left"
+
+    /** Joins a DataFrame with Bigtable based on the provided parameters.
+      *
+      * This function fetches data from Bigtable and joins it with a source DataFrame using either
+      * a **shuffle join** (default) or a **map-side join** (if specified). The join type can be "inner" or "left".
+      *
+      * ### Example Usage:
+      * {{{
+      * val joinConfig: Map[String, String] = Map(
+      *     "spark.bigtable.project.id" -> projectId, // Required
+      *     "spark.bigtable.instance.id" -> instanceId, // Required
+      *     "catalog" -> catalog, // Required
+      *     "join.type" -> "left",  // Options: "inner", "left" (default: "inner")
+      *     "columns.required" -> "order_id,product_id,amount", // Optional
+      *     "range.partition.enabled" -> "false", // Default is true. If already partitioned, set to "false"
+      *     "partition.count" -> "1000", // Optional
+      *     "batch.rowKeySize" -> "10000",  // Default batch size is 25K
+      *     "alias.name" -> "bt" // Optional, can be used in join column expression
+      * )
+      * val joinedDf = df.as("src").joinWithBigtable(joinConfig, "col1", $"src.col1" === $"bt.col2")
+      * }}}
+      *
+      * @param params      Configuration parameters for the Bigtable join.
+      * @param srcRowKeyCol Column name in the source DataFrame used for joining.
+      * @param usingColumns   Optional join condition. Can be a Column expression or a sequence of column names.
+      * @param spark       Implicit Spark session.
+      * @return            A DataFrame resulting from the join operation.
+      */
+    def joinWithBigtable(
+        params: Map[String, String],
+        srcRowKeyCol: String,
+        usingColumns: Any = ""
+    )(implicit spark: SparkSession): DataFrame = {
+
+      // Extract required parameters
+      val joinType = params.getOrElse(JOIN_TYPE, DEFAULT_JOIN_TYPE).toLowerCase
+      if (!List(DEFAULT_JOIN_TYPE, LEFT_JOIN).exists(joinType.startsWith)) {
+        val errorMsg = s"$joinType: Not a valid join type - It should be either left or inner"
+        throw new RuntimeException(errorMsg)
+      }
+      val requiredColumns = extractRequiredColumns(params)
+      val rangePartitionEnabled =
+        params.getOrElse(RANGE_PARTITION_ENABLED, DEFAULT_RANGE_PARTITION_ENABLED).toBoolean
+      val aliasName = params.getOrElse(ALIAS_NAME, DEFAULT_ALIAS_NAME)
+      // Create Bigtable catalog and schema
+      val catalog = BigtableTableCatalog(params)
+      val bigtableSchema = constructBigtableSchema(catalog, requiredColumns)
+
+      // Determine partitioning strategy
+      val sortedSrcDf = if (rangePartitionEnabled) {
+        val partitionNumber = params
+          .get(PARTITION_COUNT)
+          .map(_.toInt)
+          .getOrElse(leftDf.rdd.getNumPartitions)
+        leftDf.repartitionByRange(partitionNumber, col(srcRowKeyCol))
+      } else leftDf
+
+      // Fetch Bigtable data
+      val btDf = fetchBigtableData(params, sortedSrcDf, srcRowKeyCol, bigtableSchema, catalog)
+      val btAliasDf = if (aliasName.isEmpty) btDf else btDf.as(aliasName)
+      // Perform the join based on the specified condition
+      usingColumns match {
+        case joinExpr: Array[String] => sortedSrcDf.join(btAliasDf, joinExpr, joinType)
+        case joinExpr: Seq[String]   => sortedSrcDf.join(btAliasDf, joinExpr, joinType)
+        case joinExpr: Column        => sortedSrcDf.join(btAliasDf, joinExpr, joinType)
+        case _: String               => sortedSrcDf.join(btAliasDf, srcRowKeyCol, joinType)
+      }
+    }
+
+    /** Extracts the required column names from parameters, returns an empty array if none are specified. */
+    private def extractRequiredColumns(parameters: Map[String, String]): Array[String] = {
+      parameters.getOrElse(COLUMNS_REQUIRED, "").split(",").map(_.trim).filter(_.nonEmpty)
+    }
+
+    /** Constructs the schema for Bigtable based on the required columns.
+      *
+      * @param catalog        The Bigtable catalog containing schema mappings.
+      * @param requiredColumns Array of columns required in the output schema.
+      * @return StructType representing the final schema.
+      */
+    private def constructBigtableSchema(
+        catalog: BigtableTableCatalog,
+        requiredColumns: Array[String]
+    ): StructType = {
+      val structFields = if (requiredColumns.nonEmpty) {
+        requiredColumns.map { columnName =>
+          val field = catalog.sMap.getField(columnName)
+          StructField(field.sparkColName, field.dt)
+        }
+      } else catalog.sMap.toFields.toArray
+
+      StructType(structFields)
+    }
+
+    /** Fetches data from Bigtable for the given DataFrame's join keys.
+      *
+      * This method extracts row keys from the source DataFrame, queries Bigtable in batches,
+      * and returns the matching rows as a DataFrame.
+      *
+      * @param parameters     Configuration map for Bigtable connection and batch settings.
+      * @param sortedSrcDf    Source DataFrame, pre-sorted by join keys.
+      * @param srcRowKeyCol    Columns used as row keys for lookup in Bigtable.
+      * @param bigtableSchema Expected schema of the Bigtable data.
+      * @param catalog        Bigtable table catalog containing schema mappings.
+      * @param spark          Implicit Spark session.
+      * @return               DataFrame with data fetched from Bigtable.
+      */
+    private def fetchBigtableData(
+        parameters: Map[String, String],
+        sortedSrcDf: DataFrame,
+        srcRowKeyCol: String,
+        bigtableSchema: StructType,
+        catalog: BigtableTableCatalog
+    )(implicit spark: SparkSession): DataFrame = {
+
+      // Extract required column names and configure Bigtable client
+      val (clientKey, orderedFields, batchSize) =
+        getBigtableConfig(parameters, bigtableSchema, catalog)
+
+      // Fetch Bigtable rows based on join keys from the source DataFrame
+      val bigtableRdd = sortedSrcDf
+        .select(srcRowKeyCol)
+        .rdd
+        .mapPartitionsWithIndex { (partitionIndex, rows) =>
+          val rowKeys = rows.map(_.getAs[String](srcRowKeyCol))
+          val btRows =
+            fetchBigtableRows(rowKeys, clientKey, catalog.name, partitionIndex, batchSize)
+          btRows.map(row => ReadRowConversions.buildRow(orderedFields, row, catalog))
+        }
+
+      // Convert RDD to DataFrame and return
+      spark.createDataFrame(bigtableRdd, bigtableSchema)
+    }
+
+    /** Extracts and initializes the Bigtable client configuration.
+      *
+      * @param parameters Configuration parameters for Bigtable.
+      * @param bigtableSchema Schema of the Bigtable table.
+      * @param catalog Bigtable catalog containing schema mappings.
+      * @return A tuple containing:
+      *         - BigtableClientKey for authentication and interaction.
+      *         - Array of ordered fields mapped from the schema.
+      *         - Batch size for row key processing.
+      */
+    private def getBigtableConfig(
+        parameters: Map[String, String],
+        bigtableSchema: StructType,
+        catalog: BigtableTableCatalog
+    ): (BigtableClientKey, Array[Field], Int) = {
+      val requiredCols = bigtableSchema.map(_.name).toArray
+      val btConfig = BigtableSparkConfBuilder().fromMap(parameters).build()
+      val clientKey = new BigtableClientKey(btConfig, UserAgentInformation.RDD_TEXT)
+      val orderedFields = requiredCols.map(catalog.sMap.getField)
+      val batchSize = parameters.getOrElse(BATCH_ROWKEY_SIZE, DEFAULT_BATCH_SIZE).toInt
+      (clientKey, orderedFields, batchSize)
+    }
+
+    /** Fetches rows from a Bigtable table based on the provided row keys.
+      *
+      * @param rowKeys        Array of row keys to be fetched.
+      * @param clientKey      The Bigtable client configuration key.
+      * @param tableId        The ID of the Bigtable table to query.
+      * @param pNumber        The partition number (for logging purposes).
+      * @param rowKeyBatchSize The size of each batch of row keys for querying Bigtable.
+      * @return An iterator of BigtableRow objects containing the retrieved rows.
+      */
+    private def fetchBigtableRows(
+        rowKeys: Iterator[String],
+        clientKey: BigtableClientKey,
+        tableId: String,
+        pNumber: Int,
+        rowKeyBatchSize: Int
+    ): Iterator[BigtableRow] = {
+      try {
+        val rowKeyBatches = rowKeys.grouped(rowKeyBatchSize)
+        rowKeyBatches.flatMap { batch =>
+          val clientHandle = BigtableDataClientBuilder.getHandle(clientKey)
+          val bigtableClient = clientHandle.getClient()
+          val query = Query.create(TableId.of(tableId))
+          batch.foreach { rowKey =>
+            val rowKeyBytes = ByteString.copyFrom(BytesConverter.toBytes(rowKey))
+            query.rowKey(rowKeyBytes)
+          }
+          val responseStream = bigtableClient.readRows(query)
+          convertStreamToIterator(responseStream, clientHandle)
+        }
+      } catch {
+        case e: Exception =>
+          val errorMsg =
+            s"Failed to fetch Bigtable rows for table '$tableId' in partition $pNumber. " +
+              s"RowKeyBatchSize: $rowKeyBatchSize, Total RowKeys: ${rowKeys.length}. " +
+              s"Error: ${e.getMessage}"
+          logError(errorMsg, e)
+          throw new RuntimeException(errorMsg, e)
+      }
+    }
+
+    /** Converts a Bigtable ServerStream into an Iterator. */
+    private def convertStreamToIterator(
+        stream: ServerStream[BigtableRow],
+        clientHandle: BigtableDataClientBuilder.DataClientHandle
+    ): Iterator[BigtableRow] = {
+      val rowStreamIterator = stream.iterator()
+      new Iterator[BigtableRow] {
+        override def hasNext: Boolean = {
+          if (!rowStreamIterator.hasNext) {
+            stream.cancel()
+            clientHandle.close()
+            false
+          } else true
+        }
+        override def next(): BigtableRow = rowStreamIterator.next()
+      }
+    }
+  }
+}

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/join/BigtableJoinImplicitTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/join/BigtableJoinImplicitTest.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigtable.join
+
+import com.google.bigtable.v2.SampleRowKeysResponse
+import com.google.cloud.spark.bigtable.Logging
+import com.google.cloud.spark.bigtable.fakeserver.{
+  FakeCustomDataService,
+  FakeGenericDataService,
+  FakeServerBuilder
+}
+import com.google.protobuf.ByteString
+import org.apache.spark.sql.functions.{col, expr}
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import scala.util.Random
+
+class BigtableJoinImplicitTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with Logging {
+  @transient lazy implicit val spark: SparkSession = SparkSession
+    .builder()
+    .appName("BigtableJoinTest")
+    .master("local[*]")
+    .getOrCreate()
+
+  import spark.implicits._
+
+  var leftDf: DataFrame = _
+
+  val basicCatalog: String =
+    s"""{
+       |"table":{"name":"tableName"},
+       |"rowkey":"stringCol",
+       |"columns":{
+       |"id":{"cf":"rowkey", "col":"stringCol", "type":"string"},
+       |"col1":{"cf":"cf1", "col":"col1", "type":"string"}
+       |}
+       |}""".stripMargin
+
+  var fakeCustomDataService: FakeCustomDataService = _
+  var fakeGenericDataService: FakeGenericDataService = _
+  var emulatorPort: String = _
+
+  override def beforeAll(): Unit = {
+    leftDf = Seq(
+      ("row1", "value1"),
+      ("row2", "value2"),
+      ("row3", "value3")
+    ).toDF("id", "col1")
+  }
+
+  override def afterAll(): Unit = {
+    spark.stop()
+  }
+
+  override def beforeEach(): Unit = {
+    fakeCustomDataService = new FakeCustomDataService
+    val server = new FakeServerBuilder()
+      .addService(fakeCustomDataService)
+      .start
+    emulatorPort = Integer.toString(server.getPort)
+    logInfo("Bigtable mock server started on port " + emulatorPort)
+  }
+
+  import com.google.cloud.spark.bigtable.join.BigtableJoinImplicit._
+
+  test("Inner Join With Bigtable Table") {
+    addSampleData()
+    val leftCount = leftDf.count
+    val joinConfig = createParametersMap(basicCatalog)
+    val newJoinConfig1 = joinConfig ++ Map("join.type" -> "inner")
+    val newJoinConfig2 = newJoinConfig1 ++ Map("alias.name" -> "b")
+    val res1 = leftDf.joinWithBigtable(newJoinConfig1, "id")
+    val res2 = leftDf.joinWithBigtable(newJoinConfig1, "id", Seq("id"))
+    val res3 = leftDf.joinWithBigtable(newJoinConfig1, "id", Array("id"))
+    val res4 = leftDf.joinWithBigtable(newJoinConfig1, "id", List("id"))
+    val res5 = leftDf.as("a").joinWithBigtable(newJoinConfig2, "id", expr("a.id = b.id"))
+    val res6 = leftDf.as("a").joinWithBigtable(newJoinConfig2, "id", col("a.id") === col("b.id"))
+    assert(res1.count == leftCount)
+    assert(res2.count == leftCount)
+    assert(res3.count == leftCount)
+    assert(res4.count == leftCount)
+    assert(res5.count == leftCount)
+    assert(res6.count == leftCount)
+  }
+
+  test("Left Join") {
+    addSampleData()
+    val joinConfig = createParametersMap(basicCatalog)
+    val newJoinConfig = joinConfig ++ Map("join.type" -> "left")
+    val res = leftDf.joinWithBigtable(newJoinConfig, "id")
+    assert(leftDf.count == 3)
+    assert(res.count == 3)
+  }
+
+  test("Left Anti Join") {
+    addSampleData()
+    val joinConfig = createParametersMap(basicCatalog)
+    val newJoinConfig = joinConfig ++ Map("join.type" -> "left_anti")
+    val res = leftDf.joinWithBigtable(newJoinConfig, "id")
+    assert(leftDf.count == 3)
+    assert(res.count == 0)
+  }
+
+  test("Left Semi Join") {
+    addSampleData()
+    val joinConfig = createParametersMap(basicCatalog)
+    val newJoinConfig = joinConfig ++ Map("join.type" -> "left_semi")
+    val res = leftDf.joinWithBigtable(newJoinConfig, "id")
+    assert(leftDf.count == 3)
+    assert(res.count == 3)
+  }
+
+  test("Full Join") {
+    addSampleData()
+    val joinConfig = createParametersMap(basicCatalog)
+    val newJoinConfig = joinConfig ++ Map("join.type" -> "full")
+    assertThrows[RuntimeException] {
+      val res = leftDf.joinWithBigtable(newJoinConfig, "id")
+      res.count()
+    }
+  }
+
+  test("Right Join") {
+    addSampleData()
+    val joinConfig = createParametersMap(basicCatalog)
+    val newJoinConfig = joinConfig ++ Map("join.type" -> "right")
+    assertThrows[RuntimeException] {
+      val res = leftDf.joinWithBigtable(newJoinConfig, "id")
+      res.count()
+    }
+  }
+
+  def createSampleRowKeyResponse(rowKey: Array[Byte]): SampleRowKeysResponse = {
+    SampleRowKeysResponse
+      .newBuilder()
+      .setRowKey(ByteString.copyFrom(rowKey))
+      .build()
+  }
+
+  def createParametersMap(catalog: String): Map[String, String] = {
+    Map(
+      "catalog" -> catalog,
+      "spark.bigtable.project.id" -> "fake-project-id",
+      "spark.bigtable.instance.id" -> "fake-instance-id",
+      "spark.bigtable.emulator.port" -> emulatorPort
+    )
+  }
+
+  def addSampleData(): Unit = {
+    1 to 9 map (key => s"row$key") foreach { key =>
+      fakeCustomDataService.addRow(
+        key,
+        "cf1",
+        "col1",
+        Random.nextString(10)
+      )
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new Bigtable join pushdown mechanism to optimize query performance by minimizing unnecessary data movement. The implementation ensures that only relevant data is fetched from Bigtable using a pushdown approach, leveraging row key-based filtering.

Key Features:
1. Join Type Support – Supports inner and left joins.
2. Custom Join Columns – Allows users to specify additional join columns apart from the row key.
3. Range Partitioning Support – Provides an option to enable/disable range partitioning for better performance and scalability.
4. Batch Processing – Configurable batch size for row key-based filtering.
5. Alias Support – Enables aliasing for Bigtable in join expressions.
6. Bigtable table column pruning by providing required.column property value
7. Pre-partitioning the source data
etc

Configuration Details:

The join configuration supports the following parameters:

val joinConfig: Map[String, String] = Map(
  "spark.bigtable.project.id" -> projectId, // Required: Bigtable project ID
  "spark.bigtable.instance.id" -> instanceId, // Required: Bigtable instance ID
  "catalog" -> catalog, // Required: Table catalog
  "join.type" -> "left",  // Options: "inner", "left" (default: "inner")
  "columns.required" -> "order_id,product_id,amount", // Optional: Columns to fetch
  "range.partition.enabled" -> "false", // Default is true. If already partitioned, set to "false"
  "partition.count" -> "1000", // Optional: Number of partitions
  "batch.rowKeySize" -> "10000",  // Default batch size is 25K
  "alias.name" -> "bt" // Optional: Alias for Bigtable in the join expression
)

Usage Example:
val joinedDf = df.as("src").joinWithBigtable(joinConfig, "col1", $"src.col1" === $"bt.col2")

This implementation provides an efficient and scalable approach for performing Bigtable joins in Spark, reducing unnecessary data movement and improving query performance. 