### PR TITLE
chore: Refactor catalog definition parsing

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -182,7 +182,7 @@ For example this catalog:
     "id": {"cf": "rowkey", "col": "id_rowkey", "type": "string"},
   },
   "regexColumns": {
-    "metadata": {"cf": "info", "pattern": "\C*", "type": "long" }
+    "metadata": {"cf": "info", "pattern": "\\C*", "type": "long" }
   }
 }
 ```
@@ -203,6 +203,7 @@ A few caveats:
 - Because columns may contain arbitrary characters, including new lines, it is
   advisable to use `\C` as the wildcard expression, since `.` will not match on
   those
+- Control characters must be escaped
 
 ### Writing to Bigtable
 

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spark.bigtable.catalog
 
-import com.google.cloud.spark.bigtable.catalog.CatalogDefinition.RowKeyDefinition
+import com.google.cloud.spark.bigtable.catalog.CatalogDefinition.{ColumnsDefinition, RegexColumnsDefinition, RowKeyDefinition}
 import org.json4s.{DefaultFormats, Formats}
 import org.json4s._
 import org.json4s.native.JsonMethods._
@@ -72,12 +72,14 @@ object CatalogDefinition {
   }
 
   type RowKeyDefinition = String
+  type ColumnsDefinition = Map[String, ColumnDefinition]
+  type RegexColumnsDefinition = Map[String, RegexColumnDefinition]
 }
 
 case class CatalogDefinition(table: TableDefinition,
                              rowkey: RowKeyDefinition,
-                             columns: Map[String, ColumnDefinition],
-                             regexColumns: Option[Map[String, RegexColumnDefinition]])
+                             columns: ColumnsDefinition,
+                             regexColumns: RegexColumnsDefinition)
 
 case class TableDefinition(name: String)
 

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
@@ -17,9 +17,8 @@
 package com.google.cloud.spark.bigtable.catalog
 
 import com.google.cloud.spark.bigtable.catalog.CatalogDefinition.{ColumnsDefinition, RegexColumnsDefinition, RowKeyDefinition}
-import org.json4s.{DefaultFormats, Formats}
-import org.json4s._
-import org.json4s.native.JsonMethods._
+import org.json4s.{DefaultFormats, Extraction, Formats}
+import org.json4s.jackson.JsonMethods
 
 import scala.util.{Failure, Success, Try}
 
@@ -58,13 +57,13 @@ object CatalogDefinition {
       params.getOrElse(CATALOG_KEY, throw new IllegalArgumentException(
         "Bigtable catalog definition not found"))
 
-    val json = parse(catalogDefinitionJsonString)
+    val json = JsonMethods.parse(catalogDefinitionJsonString)
 
     implicit val formats: Formats = new DefaultFormats {
       override val strictOptionParsing = true
     }
 
-    Try(json.extract[CatalogDefinition]) match {
+    Try(Extraction.extract[CatalogDefinition](json)) match {
       case Success(result) => result
       case Failure(exception) => throw new IllegalArgumentException(
         "Error when parsing the Bigtable catalog", exception)

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spark.bigtable.catalog
 
 import com.google.cloud.spark.bigtable.catalog.CatalogDefinition.RowKeyDefinition

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
@@ -18,7 +18,7 @@ package com.google.cloud.spark.bigtable.catalog
 
 import com.google.cloud.spark.bigtable.catalog.CatalogDefinition.{ColumnsDefinition, RegexColumnsDefinition, RowKeyDefinition}
 import org.json4s.{DefaultFormats, Extraction, Formats}
-import org.json4s.jackson.JsonMethods
+import org.json4s.native.JsonMethods
 
 import scala.util.{Failure, Success, Try}
 

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
@@ -79,7 +79,7 @@ object CatalogDefinition {
 case class CatalogDefinition(table: TableDefinition,
                              rowkey: RowKeyDefinition,
                              columns: ColumnsDefinition,
-                             regexColumns: RegexColumnsDefinition)
+                             regexColumns: Option[RegexColumnsDefinition])
 
 case class TableDefinition(name: String)
 

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
@@ -1,10 +1,11 @@
 package com.google.cloud.spark.bigtable.catalog
 
 import com.google.cloud.spark.bigtable.catalog.CatalogDefinition.RowKeyDefinition
-import com.google.cloud.spark.bigtable.datasources.BigtableTableCatalog.tableCatalog
+import org.json4s.{DefaultFormats, Formats}
+import org.json4s._
+import org.json4s.native.JsonMethods._
 
 import scala.util.{Failure, Success, Try}
-import scala.util.parsing.json.JSON
 
 object CatalogDefinition {
   // This is the key for defining a bigtable catalog on Spark's configuration
@@ -37,113 +38,21 @@ object CatalogDefinition {
 
   // params is the full configuration map from Spark
   def apply(params: Map[String, String]): CatalogDefinition = {
-    val catalogDefinitionJson =
+    val catalogDefinitionJsonString =
       params.getOrElse(CATALOG_KEY, throw new IllegalArgumentException(
         "Bigtable catalog definition not found"))
 
-    val catalogDefinitionMap = JSON
-      .parseFull(catalogDefinitionJson) match {
-      case Some(map: Map[String, Any]) => map
-      case _ => throw new IllegalArgumentException(
-        s"Could not parse bigtable catalog definition: $catalogDefinitionJson"
-      )
+    val json = parse(catalogDefinitionJsonString)
+
+    implicit val formats: Formats = new DefaultFormats {
+      override val strictOptionParsing = true
     }
 
-    val tableDefinition = getTableDefinition(catalogDefinitionMap)
-    val rowKey = catalogDefinitionMap
-      .getOrElse(ROW_KEY, throw new IllegalArgumentException(
-        f"Missing entry for $ROW_KEY in the bigtable catalog definition"
-      )).asInstanceOf[RowKeyDefinition]
-    val columnsDefinition = getColumnsDefinition(catalogDefinitionMap)
-    val regexColumnsDefinition = getRegexColumnsDefinition(catalogDefinitionMap)
-
-    new CatalogDefinition(tableDefinition, rowKey, columnsDefinition, regexColumnsDefinition)
-  }
-
-  private def getTableDefinition(
-      catalogDefinitionMap: Map[String, Any]): TableDefinition = {
-    val tableDefinition = catalogDefinitionMap
-      .getOrElse(TABLE.KEY, throw new IllegalArgumentException(
-        f"Missing entry for ${TABLE.KEY} in the Bigtable catalog"
-      )).asInstanceOf[Map[String, _]]
-
-    val tableName = tableDefinition
-      .getOrElse(TABLE.TABLE_NAME_KEY, throw new IllegalArgumentException(
-        f"Missing entry for ${TABLE.TABLE_NAME_KEY} in the Bigtable catalog"
-      )).asInstanceOf[String]
-
-    TableDefinition(tableName)
-  }
-
-  private def getColumnsDefinition(
-      catalogDefinitionMap: Map[String, Any]): ColumnsDefinition = {
-    val columnsDefinition = catalogDefinitionMap
-      .getOrElse(COLUMNS.KEY, throw new IllegalArgumentException(
-      f"Missing entry for ${COLUMNS.KEY} in the Bigtable catalog"
-    )).asInstanceOf[Map[String, Map[String, String]]]
-
-    ColumnsDefinition(columnsDefinition.map(columnDefinition =>
-      (columnDefinition._1, getColumnDefinition(columnDefinition._1, columnDefinition._2)
-    )))
-  }
-
-  private def getColumnDefinition(
-      columnName: String,
-      columnDefinition: Map[String, String]): ColumnDefinition = {
-    val columnFamily = columnDefinition
-      .get(COLUMNS.COLUMN_FAMILY_KEY)
-
-    val columnQualifier = columnDefinition
-      .getOrElse(COLUMNS.COLUMN_QUALIFIER_KEY,
-        throw new IllegalArgumentException(f"Missing " +
-          f"${COLUMNS.COLUMN_QUALIFIER_KEY} entry for column $columnName"))
-
-    val maybeType = columnDefinition.get(COLUMNS.TYPE_KEY)
-    val maybeAvro = columnDefinition.get(COLUMNS.AVRO_TYPE_NAME_KEY)
-
-    val maybeLength = columnDefinition
-      .get(COLUMNS.LENGTH_KEY)
-      .map(_.toInt)
-
-    ColumnDefinition(columnFamily, columnQualifier, maybeType, maybeAvro, maybeLength)
-  }
-
-  private def getRegexColumnsDefinition(
-      catalogDefinitionMap: Map[String, Any]): Option[RegexColumnsDefinition] = {
-    catalogDefinitionMap.get(REGEX_COLUMNS.KEY) match {
-      case Some(regexColumnsDefinition: Map[String, Map[String, String]]) =>
-        Some(
-          RegexColumnsDefinition(
-            regexColumnsDefinition.map(
-              columnDefinition =>
-                (columnDefinition._1,
-                  getRegexColumnDefinition(columnDefinition._1, columnDefinition._2)
-          ))))
-      case _ => None
+    Try(json.extract[CatalogDefinition]) match {
+      case Success(result) => result
+      case Failure(exception) => throw new IllegalArgumentException(
+        "Error when parsing the Bigtable catalog", exception)
     }
-  }
-
-  private def getRegexColumnDefinition(
-      columnName: String,
-      columnDefinition: Map[String, String]): RegexColumnDefinition = {
-    val columnFamily = columnDefinition
-      .getOrElse(REGEX_COLUMNS.COLUMN_FAMILY_KEY,
-        throw new IllegalArgumentException(f"Missing " +
-          f"${REGEX_COLUMNS.COLUMN_FAMILY_KEY} entry for regex column $columnName"))
-
-    val pattern = columnDefinition
-      .getOrElse(REGEX_COLUMNS.REGEX_PATTERN_KEY,
-        throw new IllegalArgumentException(f"Missing " +
-          f"${REGEX_COLUMNS.REGEX_PATTERN_KEY} entry for regex column $columnName"))
-
-    val maybeType = columnDefinition.get(REGEX_COLUMNS.TYPE_KEY)
-    val maybeAvro = columnDefinition.get(REGEX_COLUMNS.AVRO_TYPE_NAME_KEY)
-
-    val maybeLength = columnDefinition
-      .get(REGEX_COLUMNS.LENGTH_KEY)
-      .map(_.toInt)
-
-    RegexColumnDefinition(columnFamily, pattern, maybeType, maybeAvro, maybeLength)
   }
 
   type RowKeyDefinition = String
@@ -151,23 +60,19 @@ object CatalogDefinition {
 
 case class CatalogDefinition(table: TableDefinition,
                              rowkey: RowKeyDefinition,
-                             columns: ColumnsDefinition,
-                             regexColumns: Option[RegexColumnsDefinition])
+                             columns: Map[String, ColumnDefinition],
+                             regexColumns: Option[Map[String, RegexColumnDefinition]])
 
 case class TableDefinition(name: String)
-
-case class ColumnsDefinition(columns: Map[String, ColumnDefinition])
 
 case class ColumnDefinition(cf: Option[String],
                             col: String,
                             `type`: Option[String],
                             avro: Option[String],
-                            length: Option[Int])
-
-case class RegexColumnsDefinition(columns: Map[String, RegexColumnDefinition])
+                            length: Option[String])
 
 case class RegexColumnDefinition(cf: String,
                        pattern: String,
                        `type`: Option[String],
                        avro: Option[String],
-                       length: Option[Int])
+                       length: Option[String])

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinition.scala
@@ -1,0 +1,173 @@
+package com.google.cloud.spark.bigtable.catalog
+
+import com.google.cloud.spark.bigtable.catalog.CatalogDefinition.RowKeyDefinition
+import com.google.cloud.spark.bigtable.datasources.BigtableTableCatalog.tableCatalog
+
+import scala.util.{Failure, Success, Try}
+import scala.util.parsing.json.JSON
+
+object CatalogDefinition {
+  // This is the key for defining a bigtable catalog on Spark's configuration
+  val CATALOG_KEY = "catalog"
+
+  object TABLE {
+    val KEY = "table"
+    val TABLE_NAME_KEY = "name"
+  }
+
+  val ROW_KEY = "rowkey"
+
+  object COLUMNS {
+    val KEY = "columns"
+    val COLUMN_FAMILY_KEY = "cf"
+    val COLUMN_QUALIFIER_KEY = "col"
+    val TYPE_KEY = "type"
+    val AVRO_TYPE_NAME_KEY = "avro"
+    val LENGTH_KEY = "length"
+  }
+
+  object REGEX_COLUMNS {
+    val KEY = "regexColumns"
+    val COLUMN_FAMILY_KEY = "cf"
+    val REGEX_PATTERN_KEY = "pattern"
+    val TYPE_KEY = "type"
+    val AVRO_TYPE_NAME_KEY = "avro"
+    val LENGTH_KEY = "length"
+  }
+
+  // params is the full configuration map from Spark
+  def apply(params: Map[String, String]): CatalogDefinition = {
+    val catalogDefinitionJson =
+      params.getOrElse(CATALOG_KEY, throw new IllegalArgumentException(
+        "Bigtable catalog definition not found"))
+
+    val catalogDefinitionMap = JSON
+      .parseFull(catalogDefinitionJson) match {
+      case Some(map: Map[String, Any]) => map
+      case _ => throw new IllegalArgumentException(
+        s"Could not parse bigtable catalog definition: $catalogDefinitionJson"
+      )
+    }
+
+    val tableDefinition = getTableDefinition(catalogDefinitionMap)
+    val rowKey = catalogDefinitionMap
+      .getOrElse(ROW_KEY, throw new IllegalArgumentException(
+        f"Missing entry for $ROW_KEY in the bigtable catalog definition"
+      )).asInstanceOf[RowKeyDefinition]
+    val columnsDefinition = getColumnsDefinition(catalogDefinitionMap)
+    val regexColumnsDefinition = getRegexColumnsDefinition(catalogDefinitionMap)
+
+    new CatalogDefinition(tableDefinition, rowKey, columnsDefinition, regexColumnsDefinition)
+  }
+
+  private def getTableDefinition(
+      catalogDefinitionMap: Map[String, Any]): TableDefinition = {
+    val tableDefinition = catalogDefinitionMap
+      .getOrElse(TABLE.KEY, throw new IllegalArgumentException(
+        f"Missing entry for ${TABLE.KEY} in the Bigtable catalog"
+      )).asInstanceOf[Map[String, _]]
+
+    val tableName = tableDefinition
+      .getOrElse(TABLE.TABLE_NAME_KEY, throw new IllegalArgumentException(
+        f"Missing entry for ${TABLE.TABLE_NAME_KEY} in the Bigtable catalog"
+      )).asInstanceOf[String]
+
+    TableDefinition(tableName)
+  }
+
+  private def getColumnsDefinition(
+      catalogDefinitionMap: Map[String, Any]): ColumnsDefinition = {
+    val columnsDefinition = catalogDefinitionMap
+      .getOrElse(COLUMNS.KEY, throw new IllegalArgumentException(
+      f"Missing entry for ${COLUMNS.KEY} in the Bigtable catalog"
+    )).asInstanceOf[Map[String, Map[String, String]]]
+
+    ColumnsDefinition(columnsDefinition.map(columnDefinition =>
+      (columnDefinition._1, getColumnDefinition(columnDefinition._1, columnDefinition._2)
+    )))
+  }
+
+  private def getColumnDefinition(
+      columnName: String,
+      columnDefinition: Map[String, String]): ColumnDefinition = {
+    val columnFamily = columnDefinition
+      .get(COLUMNS.COLUMN_FAMILY_KEY)
+
+    val columnQualifier = columnDefinition
+      .getOrElse(COLUMNS.COLUMN_QUALIFIER_KEY,
+        throw new IllegalArgumentException(f"Missing " +
+          f"${COLUMNS.COLUMN_QUALIFIER_KEY} entry for column $columnName"))
+
+    val maybeType = columnDefinition.get(COLUMNS.TYPE_KEY)
+    val maybeAvro = columnDefinition.get(COLUMNS.AVRO_TYPE_NAME_KEY)
+
+    val maybeLength = columnDefinition
+      .get(COLUMNS.LENGTH_KEY)
+      .map(_.toInt)
+
+    ColumnDefinition(columnFamily, columnQualifier, maybeType, maybeAvro, maybeLength)
+  }
+
+  private def getRegexColumnsDefinition(
+      catalogDefinitionMap: Map[String, Any]): Option[RegexColumnsDefinition] = {
+    catalogDefinitionMap.get(REGEX_COLUMNS.KEY) match {
+      case Some(regexColumnsDefinition: Map[String, Map[String, String]]) =>
+        Some(
+          RegexColumnsDefinition(
+            regexColumnsDefinition.map(
+              columnDefinition =>
+                (columnDefinition._1,
+                  getRegexColumnDefinition(columnDefinition._1, columnDefinition._2)
+          ))))
+      case _ => None
+    }
+  }
+
+  private def getRegexColumnDefinition(
+      columnName: String,
+      columnDefinition: Map[String, String]): RegexColumnDefinition = {
+    val columnFamily = columnDefinition
+      .getOrElse(REGEX_COLUMNS.COLUMN_FAMILY_KEY,
+        throw new IllegalArgumentException(f"Missing " +
+          f"${REGEX_COLUMNS.COLUMN_FAMILY_KEY} entry for regex column $columnName"))
+
+    val pattern = columnDefinition
+      .getOrElse(REGEX_COLUMNS.REGEX_PATTERN_KEY,
+        throw new IllegalArgumentException(f"Missing " +
+          f"${REGEX_COLUMNS.REGEX_PATTERN_KEY} entry for regex column $columnName"))
+
+    val maybeType = columnDefinition.get(REGEX_COLUMNS.TYPE_KEY)
+    val maybeAvro = columnDefinition.get(REGEX_COLUMNS.AVRO_TYPE_NAME_KEY)
+
+    val maybeLength = columnDefinition
+      .get(REGEX_COLUMNS.LENGTH_KEY)
+      .map(_.toInt)
+
+    RegexColumnDefinition(columnFamily, pattern, maybeType, maybeAvro, maybeLength)
+  }
+
+  type RowKeyDefinition = String
+}
+
+case class CatalogDefinition(table: TableDefinition,
+                             rowkey: RowKeyDefinition,
+                             columns: ColumnsDefinition,
+                             regexColumns: Option[RegexColumnsDefinition])
+
+case class TableDefinition(name: String)
+
+case class ColumnsDefinition(columns: Map[String, ColumnDefinition])
+
+case class ColumnDefinition(cf: Option[String],
+                            col: String,
+                            `type`: Option[String],
+                            avro: Option[String],
+                            length: Option[Int])
+
+case class RegexColumnsDefinition(columns: Map[String, RegexColumnDefinition])
+
+case class RegexColumnDefinition(cf: String,
+                       pattern: String,
+                       `type`: Option[String],
+                       avro: Option[String],
+                       length: Option[Int])

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/CatalogColumnMappingTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/CatalogColumnMappingTest.scala
@@ -425,7 +425,7 @@ class CatalogColumnMappingTest
          |"key":{"cf":"rowkey", "col":"row-key", "type":"string"}
          |},
          |"regexColumns":{
-         |"someCol":{"cf":"cf1", "pattern":"\\X", "type":"string"}
+         |"someCol":{"cf":"cf1", "pattern":"\\\\X", "type":"string"}
          |}
          |}""".stripMargin
 

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/CatalogColumnMappingTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/CatalogColumnMappingTest.scala
@@ -369,6 +369,11 @@ class CatalogColumnMappingTest
     // To test we are using re2 we exercise some of the intentional differences
     // from re2 syntax to other regex flavors listed at
     // https://swtch.com/~rsc/regexp/regexp3.html#caveats as of May 9 2025
+    // Note that we are escaping the pattern twice: We want the json to look
+    // like: `"pattern": "a\\va"` since json cannot have unescaped control
+    // characters in strings, so we use `a\\\\va' with 2 escapes: `a{\\}{\\}va`
+    // which will result in `a\\va`, so that the control character `\v` is
+    // escaped at the json string
     val catalog =
       s"""{
          |"table":{"name":"tableName"},
@@ -377,7 +382,7 @@ class CatalogColumnMappingTest
          |"key":{"cf":"rowkey", "col":"row-key", "type":"string"}
          |},
          |"regexColumns":{
-         |"someCol":{"cf":"cf1", "pattern":"a\\va", "type":"string"}
+         |"someCol":{"cf":"cf1", "pattern":"a\\\\va", "type":"string"}
          |}
          |}""".stripMargin
 

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinitionTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinitionTest.scala
@@ -17,14 +17,14 @@ class CatalogDefinitionTest extends AnyFunSuite with Logging {
          |    "col": "expected-col-1",
          |    "type": "expected-type-1",
          |    "avro": "expected-avro-1",
-         |    "length": 1
+         |    "length": "1"
          |  },
          |  "expected-col-2": {
          |    "cf": "expected-cf-2",
          |    "col": "expected-col-2",
          |    "type":"expected-type-2",
          |    "avro": "expected-avro-2",
-         |    "length": 2
+         |    "length": "2"
          |  }
          |},
          |"regexColumns": {
@@ -33,17 +33,17 @@ class CatalogDefinitionTest extends AnyFunSuite with Logging {
          |    "pattern": "expected-regex-col-1",
          |    "type": "expected-regex-type-1",
          |    "avro": "expected-avro-3",
-         |    "length": 3
+         |    "length": "3"
          |  },
          |  "expected-regex-col-2": {
          |    "cf": "expected-regex-cf-2",
          |    "pattern": "expected-regex-col-2",
          |    "type":"expected-regex-type-2",
          |    "avro": "expected-avro-4",
-         |    "length": 4
+         |    "length": "4"
          |  }
          |}
-         |}"""
+         |}""".stripMargin
 
     val actualDefinition = CatalogDefinition(Map(CatalogDefinition.CATALOG_KEY -> catalog))
 
@@ -76,7 +76,7 @@ class CatalogDefinitionTest extends AnyFunSuite with Logging {
           Some("expected-avro-3"),
           Some(3)
         ),
-        "expected-col-2" -> RegexColumnDefinition(
+        "expected-regex-col-2" -> RegexColumnDefinition(
           "expected-regex-cf-2",
           "expected-regex-col-2",
           Some("expected-regex-type-2"),
@@ -85,5 +85,111 @@ class CatalogDefinitionTest extends AnyFunSuite with Logging {
         )
       )
     )))
+  }
+
+  test("Works with only minimum required settings") {
+    val catalog =
+      s"""{
+         |"table": {
+         |  "name": "expected-table-name"
+         |},
+         |"rowkey": "expected-row-key",
+         |"columns": {
+         |  "some-col": {
+         |    "col": "col1"
+         |  }
+         |}
+         |}""".stripMargin
+
+    val actualDefinition = CatalogDefinition(Map(CatalogDefinition.CATALOG_KEY -> catalog))
+
+    assert(actualDefinition.table.name == "expected-table-name")
+    assert(actualDefinition.rowkey == "expected-row-key")
+    assert(actualDefinition.columns == ColumnsDefinition(
+      Map(
+        "some-col" -> ColumnDefinition(
+          None,
+          "col1",
+          None,
+          None,
+          None
+        ),
+      )
+    ))
+  }
+
+  test("Missing table setting throws exception") {
+    val catalog =
+      s"""{
+         |"rowkey": "expected-row-key",
+         |"columns": {
+         |  "some-col": {
+         |    "cf": "cf1",
+         |    "col": "col1"
+         |  }
+         |}
+         |}""".stripMargin
+
+    assertThrows[IllegalArgumentException](CatalogDefinition(Map(CatalogDefinition.CATALOG_KEY -> catalog)))
+  }
+
+  test("Missing table name throws exception") {
+    val catalog =
+      s"""{
+         |"table": {
+         |},
+         |"rowkey": "expected-row-key",
+         |"columns": {
+         |  "some-col": {
+         |    "col": "col1"
+         |  }
+         |}
+         |}""".stripMargin
+
+    assertThrows[IllegalArgumentException](CatalogDefinition(Map(CatalogDefinition.CATALOG_KEY -> catalog)))
+  }
+
+  test("Missing rowkey throws exception") {
+    val catalog =
+      s"""{
+         |"table": {
+         |  "name": "expected-table-name"
+         |},
+         |"columns": {
+         |  "some-col": {
+         |    "col": "col1"
+         |  }
+         |}
+         |}""".stripMargin
+
+    assertThrows[IllegalArgumentException](CatalogDefinition(Map(CatalogDefinition.CATALOG_KEY -> catalog)))
+  }
+
+  test("Missing columns throws exception") {
+    val catalog =
+      s"""{
+         |"table": {
+         |  "name": "expected-table-name"
+         |},
+         |"rowkey": "row"
+         |}""".stripMargin
+
+    assertThrows[IllegalArgumentException](CatalogDefinition(Map(CatalogDefinition.CATALOG_KEY -> catalog)))
+  }
+
+  test("Column without qualifier throws exception") {
+    val catalog =
+      s"""{
+         |"table": {
+         |  "name": "expected-table-name"
+         |},
+         |"rowkey": "row",
+         |"columns": {
+         |  "some-col": {
+         |  }
+         |}
+         |}""".stripMargin
+
+    assertThrows[IllegalArgumentException](CatalogDefinition(Map(CatalogDefinition.CATALOG_KEY -> catalog)))
   }
 }

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinitionTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinitionTest.scala
@@ -1,0 +1,89 @@
+package com.google.cloud.spark.bigtable.catalog
+
+import com.google.cloud.spark.bigtable.Logging
+import org.scalatest.funsuite.AnyFunSuite
+
+class CatalogDefinitionTest extends AnyFunSuite with Logging {
+  test("All properties are parsed") {
+    val catalog =
+      s"""{
+         |"table": {
+         |  "name": "expected-table-name"
+         |},
+         |"rowkey": "expected-row-key",
+         |"columns": {
+         |  "expected-col-1": {
+         |    "cf": "expected-cf-1",
+         |    "col": "expected-col-1",
+         |    "type": "expected-type-1",
+         |    "avro": "expected-avro-1",
+         |    "length": 1
+         |  },
+         |  "expected-col-2": {
+         |    "cf": "expected-cf-2",
+         |    "col": "expected-col-2",
+         |    "type":"expected-type-2",
+         |    "avro": "expected-avro-2",
+         |    "length": 2
+         |  }
+         |},
+         |"regexColumns": {
+         |  "expected-regex-col-1": {
+         |    "cf": "expected-regex-cf-1",
+         |    "pattern": "expected-regex-col-1",
+         |    "type": "expected-regex-type-1",
+         |    "avro": "expected-avro-3",
+         |    "length": 3
+         |  },
+         |  "expected-regex-col-2": {
+         |    "cf": "expected-regex-cf-2",
+         |    "pattern": "expected-regex-col-2",
+         |    "type":"expected-regex-type-2",
+         |    "avro": "expected-avro-4",
+         |    "length": 4
+         |  }
+         |}
+         |}"""
+
+    val actualDefinition = CatalogDefinition(Map(CatalogDefinition.CATALOG_KEY -> catalog))
+
+    assert(actualDefinition.table.name == "expected-table-name")
+    assert(actualDefinition.rowkey == "expected-row-key")
+    assert(actualDefinition.columns == ColumnsDefinition(
+      Map(
+        "expected-col-1" -> ColumnDefinition(
+          Some("expected-cf-1"),
+          "expected-col-1",
+          Some("expected-type-1"),
+          Some("expected-avro-1"),
+          Some(1)
+        ),
+        "expected-col-2" -> ColumnDefinition(
+          Some("expected-cf-2"),
+          "expected-col-2",
+          Some("expected-type-2"),
+          Some("expected-avro-2"),
+          Some(2)
+        )
+      )
+    ))
+    assert(actualDefinition.regexColumns.contains(RegexColumnsDefinition(
+      Map(
+        "expected-regex-col-1" -> RegexColumnDefinition(
+          "expected-regex-cf-1",
+          "expected-regex-col-1",
+          Some("expected-regex-type-1"),
+          Some("expected-avro-3"),
+          Some(3)
+        ),
+        "expected-col-2" -> RegexColumnDefinition(
+          "expected-regex-cf-2",
+          "expected-regex-col-2",
+          Some("expected-regex-type-2"),
+          Some("expected-avro-4"),
+          Some(4)
+        )
+      )
+    )))
+  }
+}

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinitionTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinitionTest.scala
@@ -49,42 +49,41 @@ class CatalogDefinitionTest extends AnyFunSuite with Logging {
 
     assert(actualDefinition.table.name == "expected-table-name")
     assert(actualDefinition.rowkey == "expected-row-key")
-    assert(actualDefinition.columns == ColumnsDefinition(
+    assert(actualDefinition.columns ==
       Map(
         "expected-col-1" -> ColumnDefinition(
           Some("expected-cf-1"),
           "expected-col-1",
           Some("expected-type-1"),
           Some("expected-avro-1"),
-          Some(1)
+          Some("1")
         ),
         "expected-col-2" -> ColumnDefinition(
           Some("expected-cf-2"),
           "expected-col-2",
           Some("expected-type-2"),
           Some("expected-avro-2"),
-          Some(2)
+          Some("2")
         )
-      )
     ))
-    assert(actualDefinition.regexColumns.contains(RegexColumnsDefinition(
+    assert(actualDefinition.regexColumns.contains(
       Map(
         "expected-regex-col-1" -> RegexColumnDefinition(
           "expected-regex-cf-1",
           "expected-regex-col-1",
           Some("expected-regex-type-1"),
           Some("expected-avro-3"),
-          Some(3)
+          Some("3")
         ),
         "expected-regex-col-2" -> RegexColumnDefinition(
           "expected-regex-cf-2",
           "expected-regex-col-2",
           Some("expected-regex-type-2"),
           Some("expected-avro-4"),
-          Some(4)
+          Some("4")
         )
       )
-    )))
+    ))
   }
 
   test("Works with only minimum required settings") {
@@ -105,8 +104,7 @@ class CatalogDefinitionTest extends AnyFunSuite with Logging {
 
     assert(actualDefinition.table.name == "expected-table-name")
     assert(actualDefinition.rowkey == "expected-row-key")
-    assert(actualDefinition.columns == ColumnsDefinition(
-      Map(
+    assert(actualDefinition.columns == Map(
         "some-col" -> ColumnDefinition(
           None,
           "col1",
@@ -115,7 +113,7 @@ class CatalogDefinitionTest extends AnyFunSuite with Logging {
           None
         ),
       )
-    ))
+    )
   }
 
   test("Missing table setting throws exception") {

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinitionTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/catalog/CatalogDefinitionTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spark.bigtable.catalog
 
 import com.google.cloud.spark.bigtable.Logging

--- a/spark-bigtable_2.12/pom.xml
+++ b/spark-bigtable_2.12/pom.xml
@@ -35,6 +35,7 @@
     <scala.binary.version>2.12</scala.binary.version>
     <spark.version>3.5.1</spark.version>
     <re2j.version>1.8</re2j.version>
+    <json4s.version>3.7.0-M11</json4s.version>
   </properties>
 
   <dependencies>
@@ -52,6 +53,12 @@
       <groupId>com.google.re2j</groupId>
       <artifactId>re2j</artifactId>
       <version>${re2j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-native_${scala.binary.version}</artifactId>
+      <version>${json4s.version}</version>
     </dependency>
 
     <!-- To fix the "NoClassDefFoundError: com/fasterxml/jackson/core/exc/StreamConstraintsException" error with Spark 3.5-->

--- a/spark-bigtable_2.12/pom.xml
+++ b/spark-bigtable_2.12/pom.xml
@@ -57,7 +57,7 @@
 
     <dependency>
       <groupId>org.json4s</groupId>
-      <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+      <artifactId>json4s-native_${scala.binary.version}</artifactId>
       <version>${json4s.version}</version>
     </dependency>
 

--- a/spark-bigtable_2.12/pom.xml
+++ b/spark-bigtable_2.12/pom.xml
@@ -57,7 +57,7 @@
 
     <dependency>
       <groupId>org.json4s</groupId>
-      <artifactId>json4s-native_${scala.binary.version}</artifactId>
+      <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
       <version>${json4s.version}</version>
     </dependency>
 

--- a/spark-bigtable_2.12/pom.xml
+++ b/spark-bigtable_2.12/pom.xml
@@ -35,7 +35,7 @@
     <scala.binary.version>2.12</scala.binary.version>
     <spark.version>3.5.1</spark.version>
     <re2j.version>1.8</re2j.version>
-    <json4s.version>3.7.0-M11</json4s.version>
+    <upickle.version>4.2.1</upickle.version>
   </properties>
 
   <dependencies>
@@ -56,9 +56,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.json4s</groupId>
-      <artifactId>json4s-native_${scala.binary.version}</artifactId>
-      <version>${json4s.version}</version>
+      <groupId>com.lihaoyi</groupId>
+      <artifactId>upickle_${scala.binary.version}</artifactId>
+      <version>${upickle.version}</version>
     </dependency>
 
     <!-- To fix the "NoClassDefFoundError: com/fasterxml/jackson/core/exc/StreamConstraintsException" error with Spark 3.5-->

--- a/spark-bigtable_2.13/pom.xml
+++ b/spark-bigtable_2.13/pom.xml
@@ -35,6 +35,7 @@
     <scala.binary.version>2.13</scala.binary.version>
     <spark.version>3.5.1</spark.version>
     <re2j.version>1.8</re2j.version>
+    <json4s.version>3.7.0-M11</json4s.version>
   </properties>
 
   <dependencies>
@@ -52,6 +53,12 @@
       <groupId>com.google.re2j</groupId>
       <artifactId>re2j</artifactId>
       <version>${re2j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-native_${scala.binary.version}</artifactId>
+      <version>${json4s.version}</version>
     </dependency>
 
     <!-- To fix the "NoClassDefFoundError: com/fasterxml/jackson/core/exc/StreamConstraintsException" error with Spark 3.5-->

--- a/spark-bigtable_2.13/pom.xml
+++ b/spark-bigtable_2.13/pom.xml
@@ -57,7 +57,7 @@
 
     <dependency>
       <groupId>org.json4s</groupId>
-      <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+      <artifactId>json4s-native_${scala.binary.version}</artifactId>
       <version>${json4s.version}</version>
     </dependency>
 

--- a/spark-bigtable_2.13/pom.xml
+++ b/spark-bigtable_2.13/pom.xml
@@ -57,7 +57,7 @@
 
     <dependency>
       <groupId>org.json4s</groupId>
-      <artifactId>json4s-native_${scala.binary.version}</artifactId>
+      <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
       <version>${json4s.version}</version>
     </dependency>
 

--- a/spark-bigtable_2.13/pom.xml
+++ b/spark-bigtable_2.13/pom.xml
@@ -35,7 +35,7 @@
     <scala.binary.version>2.13</scala.binary.version>
     <spark.version>3.5.1</spark.version>
     <re2j.version>1.8</re2j.version>
-    <json4s.version>3.7.0-M11</json4s.version>
+    <upickle.version>4.2.1</upickle.version>
   </properties>
 
   <dependencies>
@@ -56,9 +56,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.json4s</groupId>
-      <artifactId>json4s-native_${scala.binary.version}</artifactId>
-      <version>${json4s.version}</version>
+      <groupId>com.lihaoyi</groupId>
+      <artifactId>upickle_${scala.binary.version}</artifactId>
+      <version>${upickle.version}</version>
     </dependency>
 
     <!-- To fix the "NoClassDefFoundError: com/fasterxml/jackson/core/exc/StreamConstraintsException" error with Spark 3.5-->

--- a/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/datasources/BigtableTableCatalog.scala
+++ b/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/datasources/BigtableTableCatalog.scala
@@ -272,9 +272,22 @@ object BigtableTableCatalog {
   val pattern: String = CatalogDefinition.REGEX_COLUMNS.REGEX_PATTERN_KEY
 
   /** User provide table schema definition
-   * {"tablename":"name", "rowkey":"key1:key2",
-   * "columns":{"col1":{"cf":"cf1", "col":"col1", "type":"type1"},
-   * "col2":{"cf":"cf2", "col":"col2", "type":"type2"}}}
+   * {
+   *   "tablename": "name",
+   *   "rowkey": "key1:key2",
+   *   "columns": {
+   *     "col1": {
+   *       "cf": "cf1",
+   *       "col": "col1",
+   *       "type": "type1"
+   *     },
+   *     "col2": {
+   *       "cf": "cf2",
+   *       "col": "col2",
+   *       "type": "type2"
+   *     }
+   *   }
+   * }
    * Note that any col in the rowKey, there has to be one corresponding col defined in columns
    */
   def apply(params: Map[String, String]): BigtableTableCatalog = {

--- a/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/datasources/BigtableTableCatalog.scala
+++ b/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/datasources/BigtableTableCatalog.scala
@@ -294,7 +294,7 @@ object BigtableTableCatalog {
     val catalogDefinition = CatalogDefinition(params)
 
     val schemaMap = mutable.HashMap.empty[String, Field]
-    catalogDefinition.columns.columns.foreach {
+    catalogDefinition.columns.foreach {
       case (name, column) =>
         val f = Field(
           name,
@@ -302,26 +302,24 @@ object BigtableTableCatalog {
           column.col,
           column.`type`,
           column.avro.map(params(_)),
-          column.length.getOrElse(-1)
+          column.length.map(_.toInt).getOrElse(-1)
         )
         schemaMap.+=((name, f))
     }
 
     val cqSchemaMap = mutable.HashMap.empty[String, Field]
-    catalogDefinition.regexColumns.foreach(regexColumns =>
-      regexColumns.columns.foreach {
-        case (name, column) =>
-          val f = Field(
-            name,
-            column.cf,
-            column.pattern,
-            column.`type`,
-            column.avro.map(params(_)),
-            column.length.getOrElse(-1)
-          )
-          cqSchemaMap.+=((name, f))
-      }
-    )
+    catalogDefinition.regexColumns.foreach(_.foreach {
+      case (name, column) =>
+        val f = Field(
+          name,
+          column.cf,
+          column.pattern,
+          column.`type`,
+          column.avro.map(params(_)),
+          column.length.map(_.toInt).getOrElse(-1)
+        )
+        cqSchemaMap.+=((name, f))
+    })
     val rKey = RowKey(catalogDefinition.rowkey)
     BigtableTableCatalog(
       catalogDefinition.table.name,

--- a/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/datasources/BigtableTableCatalog.scala
+++ b/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/datasources/BigtableTableCatalog.scala
@@ -252,24 +252,24 @@ case class BigtableTableCatalog(
 
 @InterfaceAudience.Public
 object BigtableTableCatalog {
-  val tableCatalog = "catalog"
+  val tableCatalog: String = CatalogDefinition.CATALOG_KEY
   // The row key with format key1:key2 specifying table row key
-  val rowKey = "rowkey"
+  val rowKey: String = CatalogDefinition.ROW_KEY
   // The key for Bigtable table whose value specify table name (and potential future settings)
-  val table = "table"
+  val table: String = CatalogDefinition.TABLE.KEY
   // The name of Bigtable table
-  val tableName = "name"
+  val tableName: String = CatalogDefinition.TABLE.TABLE_NAME_KEY
   // The name of columns in Bigtable catalog
-  val columns = "columns"
-  val cf = "cf"
-  val col = "col"
-  val `type` = "type"
+  val columns: String = CatalogDefinition.COLUMNS.KEY
+  val cf: String = CatalogDefinition.COLUMNS.COLUMN_FAMILY_KEY
+  val col: String = CatalogDefinition.COLUMNS.COLUMN_QUALIFIER_KEY
+  val `type`: String = CatalogDefinition.COLUMNS.TYPE_KEY
   // the name of avro schema json string
-  val avro = "avro"
+  val avro: String = CatalogDefinition.COLUMNS.AVRO_TYPE_NAME_KEY
   val delimiter: Byte = 0
-  val length = "length"
-  val regexColumns = "regexColumns"
-  val pattern = "pattern"
+  val length: String = CatalogDefinition.COLUMNS.LENGTH_KEY
+  val regexColumns: String = CatalogDefinition.REGEX_COLUMNS.KEY
+  val pattern: String = CatalogDefinition.REGEX_COLUMNS.REGEX_PATTERN_KEY
 
   /** User provide table schema definition
    * {"tablename":"name", "rowkey":"key1:key2",


### PR DESCRIPTION
Part 1/n for passing column filters to the backend. Starting out with some refactoring to clean up the logic

Creates classes representing the definition of a bigtable catalog in a spark configuration.

Moves all parsing logic to these classes.