### PR TITLE
Fix regex bug in ReadRowConversions

### DIFF
--- a/examples/scala-sbt/README.md
+++ b/examples/scala-sbt/README.md
@@ -30,8 +30,9 @@ To run the job using dataproc, you can run the following command:
 gcloud dataproc jobs submit spark \
 --cluster=$BIGTABLE_SPARK_DATAPROC_CLUSTER \
 --region=$BIGTABLE_SPARK_DATAPROC_REGION \
+--project=$BIGTABLE_SPARK_PROJECT_ID \
 --class=spark.bigtable.example.WordCount \
---jars=target/scala-2.12/spark-bigtable-example-assembly-0.1.jar  \
+--jars=target/scala-2.12/spark-bigtable-example-scala2.12-assembly-0.1.jar  \
 --  \
 $BIGTABLE_SPARK_PROJECT_ID \
 $BIGTABLE_SPARK_INSTANCE_ID \

--- a/examples/scala-sbt/build.sbt
+++ b/examples/scala-sbt/build.sbt
@@ -20,7 +20,7 @@ name := "spark-bigtable-example-scala2.12"
 version := "0.1"
 scalaVersion := "2.12.18"
 val sparkBigtable = "spark-bigtable_2.12"
-val sparkBigtableVersion = "0.4.0" /* ${NEXT_VERSION_FLAG} */
+val sparkBigtableVersion = "0.7.0" /* ${NEXT_VERSION_FLAG} */
 
 
 /** build settings for scala 2.13 */
@@ -32,34 +32,34 @@ scalaVersion := "2.13.14"
 val sparkBigtable = "spark-bigtable_2.13"
 */
 
+useCoursier := false
+
 val sparkVersion = "3.5.1"
 
 resolvers += Resolver.mavenLocal
 
 libraryDependencies ++= Seq(
-  "com.google.cloud.spark.bigtable" % sparkBigtable % sparkBigtableVersion,
+  ("com.google.cloud.spark.bigtable" % sparkBigtable % sparkBigtableVersion)
+    .exclude("io.opencensus", "opencensus-contrib-http-util"),
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
   "org.slf4j" % "slf4j-reload4j" % "1.7.36",
+  "commons-codec" % "commons-codec" % "1.11",
+  "com.google.api" % "gax" % "2.51.0",
+  "com.google.auth" % "google-auth-library-credentials" % "1.24.0"
 )
 
 val scalatestVersion = "3.2.6"
-test in assembly := {}
+assembly / test := {}
 
-ThisBuild / assemblyMergeStrategy := {
-  case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
-  case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
-  case PathList("META-INF", "native", xs @ _*)         => MergeStrategy.first
-  case PathList("META-INF", "native-image", xs @ _*)         => MergeStrategy.first
-  case PathList("mozilla", "public-suffix-list.txt")         => MergeStrategy.first
-  case PathList("google", xs @ _*) => xs match {
-    case ps @ (x :: xs) if ps.last.endsWith(".proto") => MergeStrategy.first
-    case _ => MergeStrategy.deduplicate
-  }
-  case PathList("javax", xs @ _*)         => MergeStrategy.first
-  case PathList("io", "netty", xs @ _*)         => MergeStrategy.first
-  case PathList(ps @ _*) if ps.last endsWith ".proto" => MergeStrategy.first
-  case PathList(ps @ _*) if ps.last endsWith "module-info.class" => MergeStrategy.discard
-  case x =>
-    val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
-    oldStrategy(x)
+assembly / assemblyMergeStrategy := {
+  case PathList("META-INF", "services", xs @ _*) => MergeStrategy.concat
+  case PathList("META-INF", xs @ _*) =>
+    (xs map {_.toLowerCase}) match {
+      case ("manifest.mf" :: Nil) | ("index.list" :: Nil) | ("dependencies" :: Nil) =>
+        MergeStrategy.discard
+      case ps @ (x :: xs) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") || ps.last.endsWith(".rsa") =>
+        MergeStrategy.discard
+      case _ => MergeStrategy.first
+    }
+  case _ => MergeStrategy.first
 }

--- a/examples/scala-sbt/src/main/scala/spark/bigtable/example/auth/BigtableReadWithCustomAuth.scala
+++ b/examples/scala-sbt/src/main/scala/spark/bigtable/example/auth/BigtableReadWithCustomAuth.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.SparkSession
 import spark.bigtable.example.Util
 import spark.bigtable.example.WordCount.parse
 import com.google.api.gax.core.{CredentialsProvider, NoCredentialsProvider}
+import com.google.auth.Credentials
 
 import scala.util.Try
 
@@ -32,8 +33,6 @@ object BigtableReadWithCustomAuth extends App {
     .master("local[*]")
     .appName("BigtableReadWithCustomAuth")
     .getOrCreate()
-
-  val credentilasProvider = new CustomCredentialProvider()
 
   Try(Util.createExampleBigtable(spark, createNewTable, projectId, instanceId, tableName))
 

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/BigtableDefaultSource.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/BigtableDefaultSource.scala
@@ -225,9 +225,7 @@ case class BigtableRelation(
       )
 
     val fieldsOrdered = requiredColumns.map(catalog.sMap.getField)
-    readRdd.map { r =>
-      ReadRowConversions.buildRow(fieldsOrdered, r, catalog)
-    }
+    readRdd.flatMap(r => ReadRowConversions.buildRow(fieldsOrdered, r, catalog))
   }
 
   def getLineageDatasetIdentifier(

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/join/BigtableJoinImplicitCommon.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/join/BigtableJoinImplicitCommon.scala
@@ -102,7 +102,7 @@ object BigtableJoinImplicitCommon extends Serializable with Logging {
       .mapPartitionsWithIndex { (partitionIndex, rows) =>
         val rowKeys = rows.map(r => srcRowKeyField.scalaValueToBigtable(r.getAs[Any](srcRowKeyCol)))
         val btRows = fetchBigtableRows(rowKeys, bigtableConfig, catalog.name, partitionIndex)
-        btRows.map(row => ReadRowConversions.buildRow(orderedFields, row, catalog))
+        btRows.flatMap(row => ReadRowConversions.buildRow(orderedFields, row, catalog))
       }
 
     // Convert RDD to DataFrame and return

--- a/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/join/BigtableJoinImplicitCommon.scala
+++ b/spark-bigtable-core/src/main/scala/com/google/cloud/spark/bigtable/join/BigtableJoinImplicitCommon.scala
@@ -102,7 +102,9 @@ object BigtableJoinImplicitCommon extends Serializable with Logging {
       .mapPartitionsWithIndex { (partitionIndex, rows) =>
         val rowKeys = rows.map(r => srcRowKeyField.scalaValueToBigtable(r.getAs[Any](srcRowKeyCol)))
         val btRows = fetchBigtableRows(rowKeys, bigtableConfig, catalog.name, partitionIndex)
-        btRows.flatMap(row => ReadRowConversions.buildRow(orderedFields, row, catalog))
+        btRows
+          .filter(_ != null)
+          .flatMap(row => ReadRowConversions.buildRow(orderedFields, row, catalog))
       }
 
     // Convert RDD to DataFrame and return

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/CatalogColumnMappingTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/CatalogColumnMappingTest.scala
@@ -309,7 +309,7 @@ class CatalogColumnMappingTest
     assert(!result.first().getAs[Map[String, String]]("someCol").contains("any2"))
   }
 
-  test("if no bt column matches the regex we should have an empty map") {
+  test("if no bt column matches the regex the result should be empty") {
     val catalog =
       s"""{
          |"table":{"name":"tableName"},
@@ -337,7 +337,7 @@ class CatalogColumnMappingTest
       .options(createParametersMap(catalog))
       .load()
 
-    assert(result.first().getAs[Map[String, String]]("someCol").isEmpty)
+    assert(result.isEmpty)
   }
 
 

--- a/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/ReadRowConversions.scala
+++ b/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/ReadRowConversions.scala
@@ -22,8 +22,16 @@ import com.google.cloud.spark.bigtable.datasources.{BigtableTableCatalog, Field,
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.{Row => SparkRow}
 import com.google.re2j.Pattern
+import com.google.common.cache.CacheLoader
+import com.google.common.cache.CacheBuilder
 
 object ReadRowConversions extends Serializable {
+
+  @transient private lazy val patternCache = CacheBuilder.newBuilder()
+    .maximumSize(1000)
+    .build(new CacheLoader[String, Pattern]() {
+    def load(key: String) = Pattern.compile(key)
+  })
 
   private def buildRowForRegex(
       cqFields: Seq[Field],

--- a/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/ReadRowConversions.scala
+++ b/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/ReadRowConversions.scala
@@ -28,26 +28,19 @@ object ReadRowConversions extends Serializable {
   private def buildRowForRegex(
       cqFields: Seq[Field],
       bigtableRow: BigtableRow
-  ): Seq[(Field, Any)] = {
+  ): Seq[(Field, Map[String, Any])] = {
     cqFields.map { x =>
       val pattern: Pattern = Pattern.compile(x.btColName)
       val allCells: List[RowCell] = ReadRowUtil.getAllCells(bigtableRow, x.btColFamily)
       val cqAllFields = allCells
-        .filter(cell => pattern.matcher(cell.getQualifier.toStringUtf8).find())
+        .filter(cell => pattern.matcher(cell.getQualifier.toStringUtf8).matches())
         .map { cell =>
           val qualifier = cell.getQualifier.toStringUtf8
-          val cqField = Field(
-            x.sparkColName,
-            x.btColFamily,
-            qualifier,
-            x.simpleType,
-            x.avroSchema,
-            x.len
-          )
-          extractValue(cqField, bigtableRow)
+          val cellValue = cell.getValue.toByteArray
+          val value = x.bigtableToScalaValue(cellValue, 0, cellValue.length)
+          (qualifier, value)
         }
-      val cqValues = cqAllFields.map { case (field, value) => field.btColName -> value }
-      (x, cqValues.toMap)
+      (x, cqAllFields.toMap)
     }
   }
 
@@ -63,17 +56,27 @@ object ReadRowConversions extends Serializable {
       fields: Seq[Field],
       bigtableRow: BigtableRow,
       catalog: BigtableTableCatalog
-  ): SparkRow = {
+  ): Option[SparkRow] = {
     val keySeq = catalog.row.parseFieldsFromBtRow(bigtableRow)
 
     val valueSeq = fields
       .filter(!_.isRowKey)
+      .filter(field => !catalog.sMap.cqMap.contains(field.sparkColName))
       .map(field => extractValue(field, bigtableRow))
-      .toMap
     val cqFields = catalog.sMap.cqMap.values.toSeq
-    val cqValueSeq = buildRowForRegex(cqFields, bigtableRow).toMap
-    val unionedRow = keySeq ++ valueSeq ++ cqValueSeq
-    SparkRow.fromSeq((fields ++ cqFields).map(unionedRow.get(_).orNull))
+    val cqValueSeq = buildRowForRegex(cqFields, bigtableRow)
+
+    if (catalog.sMap.cqMap.nonEmpty) {
+      val nonNullValues = valueSeq.filter(_._2 != null)
+      val nonEmptyMaps = cqValueSeq.filter(!_._2.isEmpty)
+
+      if (nonNullValues.isEmpty && nonEmptyMaps.isEmpty) {
+        return None
+      }
+    }
+
+    val unionedRow = (keySeq ++ valueSeq ++ cqValueSeq).toMap
+    Some(SparkRow.fromSeq(fields.map(unionedRow.get(_).orNull)))
   }
 
   private def extractValue(field: Field, bigtableRow: BigtableRow): (Field, Any) = {


### PR DESCRIPTION
- Pattern is case insensitive
- pattern.matcher(...).find() will match any substring, the fix is to update the method to matches
- Also update buildRowForRegex and buildRow to return an Option[SparkRow] instead, to allow callers to filter out null rows.