### PR TITLE
feat: add spark 4.x support

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -51,7 +51,10 @@ apt install -y google-cloud-sdk-cbt
 
 run_unit_tests() {
     SCALA_VERSION=$1
-    CONNECTOR_MODULE=spark-bigtable_${SCALA_VERSION}
+    # Optional 2nd arg overrides the module name. Needed for the Spark 4 module,
+    # whose name (spark-bigtable-spark4_2.13) doesn't follow the
+    # spark-bigtable_<scala> pattern used by the Spark 3.x modules.
+    CONNECTOR_MODULE=${2:-spark-bigtable_${SCALA_VERSION}}
     echo "***Running connector's unit tests for ${CONNECTOR_MODULE}.***"
     ./mvnw -pl ${CONNECTOR_MODULE} -am  \
         test -B -ntp -Dclirr.skip=true -Denforcer.skip=true -Dcheckstyle.skip
@@ -62,7 +65,10 @@ run_bigtable_spark_tests() {
     SPARK_VERSION=$1
     MAVEN_PROFILES=$2
     SCALA_VERSION=$3
-    echo "***Running Spark-Bigtable tests for Spark ${SPARK_VERSION}, Scala ${SCALA_VERSION} and profile(s) ${MAVEN_PROFILES}.***"
+    # Optional 4th arg overrides the connector artifact the IT module builds
+    # against. Needed for the Spark 4 module (spark-bigtable-spark4_2.13).
+    CONNECTOR_ARTIFACT_ID=${4:-spark-bigtable_${SCALA_VERSION}}
+    echo "***Running Spark-Bigtable tests for Spark ${SPARK_VERSION}, Scala ${SCALA_VERSION}, connector ${CONNECTOR_ARTIFACT_ID} and profile(s) ${MAVEN_PROFILES}.***"
     BIGTABLE_SPARK_IT_MODULE="spark-bigtable-core-it"
     ./mvnw -pl ${BIGTABLE_SPARK_IT_MODULE} \
         failsafe:integration-test failsafe:verify \
@@ -70,7 +76,7 @@ run_bigtable_spark_tests() {
         -Dspark.version=${SPARK_VERSION} \
         -DbigtableProjectId=${BIGTABLE_PROJECT_ID} \
         -DbigtableInstanceId=${BIGTABLE_INSTANCE_ID} \
-        -Dconnector.artifact.id=spark-bigtable_${SCALA_VERSION} \
+        -Dconnector.artifact.id=${CONNECTOR_ARTIFACT_ID} \
         -Dscala.binary.version=${SCALA_VERSION} \
         -P ${MAVEN_PROFILES}
     return $?
@@ -254,6 +260,33 @@ presubmit)
     run_pyspark_test "3.3.0" "3" "2.13"
     RETURN_CODE=$(($RETURN_CODE || $?))
     run_unit_tests "2.13"
+    RETURN_CODE=$(($RETURN_CODE || $?))
+    ;;
+presubmit-spark4)
+    # Spark 4.0 requires Java 17 (this job runs on the java17 image). On Java 17
+    # Spark needs a set of --add-opens flags to reach internal JDK packages that
+    # were sealed by JPMS; without them the tests fail with IllegalAccessError
+    # (e.g. sun.nio.ch.DirectBuffer). These flags must reach the forked test JVMs
+    # too, so we set JAVA_TOOL_OPTIONS (inherited by every JVM) rather than
+    # MAVEN_OPTS (which only affects the Maven process, not the scalatest fork).
+    export JAVA_TOOL_OPTIONS="--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.io=ALL-UNNAMED \
+--add-opens=java.base/java.net=ALL-UNNAMED \
+--add-opens=java.base/java.nio=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+--add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+--add-opens=java.base/sun.nio.cs=ALL-UNNAMED \
+--add-opens=java.base/sun.security.action=ALL-UNNAMED \
+--add-opens=java.base/sun.util.calendar=ALL-UNNAMED \
+--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
+    RETURN_CODE=0
+    run_unit_tests "2.13" "spark-bigtable-spark4_2.13"
+    RETURN_CODE=$(($RETURN_CODE || $?))
+    run_bigtable_spark_tests "4.0.1" "integration" "2.13" "spark-bigtable-spark4_2.13"
     RETURN_CODE=$(($RETURN_CODE || $?))
     ;;
 all_versions)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -269,7 +269,9 @@ presubmit-spark4)
     # (e.g. sun.nio.ch.DirectBuffer). These flags must reach the forked test JVMs
     # too, so we set JAVA_TOOL_OPTIONS (inherited by every JVM) rather than
     # MAVEN_OPTS (which only affects the Maven process, not the scalatest fork).
-    export JAVA_TOOL_OPTIONS="--add-opens=java.base/java.lang=ALL-UNNAMED \
+    # Append (don't overwrite) so we preserve any JAVA_TOOL_OPTIONS the Kokoro
+    # environment already set (proxy, memory limits, diagnostic flags, etc.).
+    export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:+$JAVA_TOOL_OPTIONS }--add-opens=java.base/java.lang=ALL-UNNAMED \
 --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
 --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
 --add-opens=java.base/java.io=ALL-UNNAMED \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -84,9 +84,13 @@ run_bigtable_spark_tests() {
 
 get_bigtable_spark_jar() {
     SCALA_VERSION=$1
+    # Optional 2nd arg overrides the module (== artifactId == jar prefix). Needed
+    # for the Spark 4 module (spark-bigtable-spark4_2.13), which doesn't follow the
+    # spark-bigtable_<scala> naming.
+    CONNECTOR_MODULE=${2:-spark-bigtable_${SCALA_VERSION}}
     # This makes the script independent of the connector's version and
     # ignores the source code JAR.
-    echo $(ls spark-bigtable_${SCALA_VERSION}/target/spark-bigtable_${SCALA_VERSION}-* | grep -v sources)
+    echo $(ls ${CONNECTOR_MODULE}/target/${CONNECTOR_MODULE}-* | grep -v sources)
 }
 
 create_table_id() {
@@ -159,10 +163,18 @@ run_load_test() {
 }
 
 run_load_test_serverless() {
-    # Hardcoded to 2.13 since 2.12 is running on a cluster
-    SCALA_VERSION="2.13"
-    echo "***Running Load test for scala ${SCALA_VERSION}.***"
-    BIGTABLE_SPARK_JAR=$(get_bigtable_spark_jar ${SCALA_VERSION})
+    # Defaults to 2.13 since 2.12 is running on a cluster.
+    SCALA_VERSION=${1:-2.13}
+    # Optional 2nd arg overrides the module/jar. Needed for the Spark 4 module
+    # (spark-bigtable-spark4_2.13), which doesn't follow the spark-bigtable_<scala>
+    # naming.
+    CONNECTOR_MODULE=${2:-spark-bigtable_${SCALA_VERSION}}
+    # Optional 3rd arg pins the Dataproc Serverless runtime version. Spark 4.0.x
+    # needs runtime 3.0; leaving it empty uses the region's default runtime (which
+    # ships Spark 3.x) for the existing 2.13 load test.
+    DATAPROC_RUNTIME_VERSION=${3:-}
+    echo "***Running Load test for scala ${SCALA_VERSION}, module ${CONNECTOR_MODULE}, runtime '${DATAPROC_RUNTIME_VERSION:-default}'.***"
+    BIGTABLE_SPARK_JAR=$(get_bigtable_spark_jar ${SCALA_VERSION} ${CONNECTOR_MODULE})
     DEPS_BUCKET="bigtable-spark-test-deps"
     TEST_SCRIPT="spark-bigtable-core/test-pyspark/load_test.py"
     BASE_SCRIPT="spark-bigtable-core/test-pyspark/test_base.py"
@@ -177,6 +189,7 @@ run_load_test_serverless() {
         --deps-bucket=${DEPS_BUCKET} \
         --jars=${BIGTABLE_SPARK_JAR} \
         --subnet=${TEST_SUBNET} \
+        ${DATAPROC_RUNTIME_VERSION:+--version=${DATAPROC_RUNTIME_VERSION}} \
         ${TEST_SCRIPT} \
         --py-files=${BASE_SCRIPT} \
         -- \
@@ -193,7 +206,10 @@ run_load_test_serverless() {
 run_fuzz_tests() {
     SPARK_VERSION=$1
     SCALA_VERSION=$2
-    echo "***Running Spark-Bigtable fuzz tests for Spark ${SPARK_VERSION} and Scala ${SCALA_VERSION}.***"
+    # Optional 3rd arg overrides the connector artifact the IT module builds
+    # against. Needed for the Spark 4 module (spark-bigtable-spark4_2.13).
+    CONNECTOR_ARTIFACT_ID=${3:-spark-bigtable_${SCALA_VERSION}}
+    echo "***Running Spark-Bigtable fuzz tests for Spark ${SPARK_VERSION}, Scala ${SCALA_VERSION} and connector ${CONNECTOR_ARTIFACT_ID}.***"
     TABLE_ID=$(create_table_id "fuzz")
     create_table_with_random_splits \
       "${BIGTABLE_PROJECT_ID}" "${BIGTABLE_INSTANCE_ID}" "$TABLE_ID"
@@ -205,7 +221,7 @@ run_fuzz_tests() {
         -DbigtableProjectId="${BIGTABLE_PROJECT_ID}" \
         -DbigtableInstanceId="${BIGTABLE_INSTANCE_ID}" \
         -DbigtableTableId="${TABLE_ID}" \
-        -Dconnector.artifact.id=spark-bigtable_${SCALA_VERSION} \
+        -Dconnector.artifact.id=${CONNECTOR_ARTIFACT_ID} \
         -Dscala.binary.version=${SCALA_VERSION} \
         -P fuzz
     exit_code=$?
@@ -246,6 +262,30 @@ run_pyspark_test() {
     return $exit_code
 }
 
+# Spark 4.0 requires Java 17. On Java 17 Spark needs a set of --add-opens flags to
+# reach internal JDK packages that were sealed by JPMS; without them the tests fail
+# with IllegalAccessError (e.g. sun.nio.ch.DirectBuffer). These flags must reach the
+# forked test JVMs too, so we set JAVA_TOOL_OPTIONS (inherited by every JVM) rather
+# than MAVEN_OPTS (which only affects the Maven process, not the scalatest fork).
+# Append (don't overwrite) so we preserve any JAVA_TOOL_OPTIONS the Kokoro
+# environment already set (proxy, memory limits, diagnostic flags, etc.).
+set_spark4_java_tool_options() {
+    export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:+$JAVA_TOOL_OPTIONS }--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.io=ALL-UNNAMED \
+--add-opens=java.base/java.net=ALL-UNNAMED \
+--add-opens=java.base/java.nio=ALL-UNNAMED \
+--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+--add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+--add-opens=java.base/sun.nio.cs=ALL-UNNAMED \
+--add-opens=java.base/sun.security.action=ALL-UNNAMED \
+--add-opens=java.base/sun.util.calendar=ALL-UNNAMED \
+--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
+}
+
 case ${JOB_TYPE} in
 presubmit)
     RETURN_CODE=0
@@ -263,28 +303,8 @@ presubmit)
     RETURN_CODE=$(($RETURN_CODE || $?))
     ;;
 presubmit-spark4)
-    # Spark 4.0 requires Java 17 (this job runs on the java17 image). On Java 17
-    # Spark needs a set of --add-opens flags to reach internal JDK packages that
-    # were sealed by JPMS; without them the tests fail with IllegalAccessError
-    # (e.g. sun.nio.ch.DirectBuffer). These flags must reach the forked test JVMs
-    # too, so we set JAVA_TOOL_OPTIONS (inherited by every JVM) rather than
-    # MAVEN_OPTS (which only affects the Maven process, not the scalatest fork).
-    # Append (don't overwrite) so we preserve any JAVA_TOOL_OPTIONS the Kokoro
-    # environment already set (proxy, memory limits, diagnostic flags, etc.).
-    export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:+$JAVA_TOOL_OPTIONS }--add-opens=java.base/java.lang=ALL-UNNAMED \
---add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
---add-opens=java.base/java.io=ALL-UNNAMED \
---add-opens=java.base/java.net=ALL-UNNAMED \
---add-opens=java.base/java.nio=ALL-UNNAMED \
---add-opens=java.base/java.util=ALL-UNNAMED \
---add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
---add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED \
---add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
---add-opens=java.base/sun.nio.cs=ALL-UNNAMED \
---add-opens=java.base/sun.security.action=ALL-UNNAMED \
---add-opens=java.base/sun.util.calendar=ALL-UNNAMED \
---add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"
+    # This job runs on the java17 image; Spark 4.0 needs the JPMS --add-opens flags.
+    set_spark4_java_tool_options
     RETURN_CODE=0
     run_unit_tests "2.13" "spark-bigtable-spark4_2.13"
     RETURN_CODE=$(($RETURN_CODE || $?))
@@ -360,6 +380,25 @@ load)
     ;;
 load-2.13)
     run_load_test_serverless
+    RETURN_CODE=0
+    ;;
+# Spark 4 periodic jobs. These run on the java17 image (Spark 4 requires Java 17)
+# and target the spark-bigtable-spark4_2.13 module, so they need the JPMS
+# --add-opens flags for the forked test JVMs.
+fuzz-spark4)
+    set_spark4_java_tool_options
+    run_fuzz_tests "4.0.1" "2.13" "spark-bigtable-spark4_2.13"
+    RETURN_CODE=$?
+    ;;
+long_running-spark4)
+    set_spark4_java_tool_options
+    run_bigtable_spark_tests "4.0.1" "long-running" "2.13" "spark-bigtable-spark4_2.13"
+    RETURN_CODE=0
+    ;;
+load-spark4)
+    # Dataproc Serverless runtime 3.0 ships Spark 4.0.x / Scala 2.13. The load test
+    # driver (PySpark) runs on the serverless batch, so no local --add-opens needed.
+    run_load_test_serverless "2.13" "spark-bigtable-spark4_2.13" "3.0"
     RETURN_CODE=0
     ;;
 *)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -308,7 +308,7 @@ presubmit-spark4)
     RETURN_CODE=0
     run_unit_tests "2.13" "spark-bigtable-spark4_2.13"
     RETURN_CODE=$(($RETURN_CODE || $?))
-    run_bigtable_spark_tests "4.0.1" "integration" "2.13" "spark-bigtable-spark4_2.13"
+    run_bigtable_spark_tests "4.1.2" "integration" "2.13" "spark-bigtable-spark4_2.13"
     RETURN_CODE=$(($RETURN_CODE || $?))
     ;;
 all_versions)
@@ -387,12 +387,12 @@ load-2.13)
 # --add-opens flags for the forked test JVMs.
 fuzz-spark4)
     set_spark4_java_tool_options
-    run_fuzz_tests "4.0.1" "2.13" "spark-bigtable-spark4_2.13"
+    run_fuzz_tests "4.1.2" "2.13" "spark-bigtable-spark4_2.13"
     RETURN_CODE=$?
     ;;
 long_running-spark4)
     set_spark4_java_tool_options
-    run_bigtable_spark_tests "4.0.1" "long-running" "2.13" "spark-bigtable-spark4_2.13"
+    run_bigtable_spark_tests "4.1.2" "long-running" "2.13" "spark-bigtable-spark4_2.13"
     RETURN_CODE=0
     ;;
 load-spark4)

--- a/.kokoro/periodic/fuzz-spark4.cfg
+++ b/.kokoro/periodic/fuzz-spark4.cfg
@@ -1,0 +1,25 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+# Spark 4.0 requires Java 17, so this job uses the java17 image.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java17"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "fuzz-spark4"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}
+
+timeout_mins: 240

--- a/.kokoro/periodic/load-spark4.cfg
+++ b/.kokoro/periodic/load-spark4.cfg
@@ -1,0 +1,32 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+# Spark 4.0 requires Java 17, so this job uses the java17 image. The load test
+# itself runs on Dataproc Serverless runtime 3.0 (Spark 4.0.x / Scala 2.13),
+# pinned via --version in the load-spark4 JOB_TYPE case in build.sh.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java17"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "load-spark4"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}
+
+env_vars: {
+  key: "DATAPROC_SERVERLESS_REGION"
+  value: "us-central1"
+}
+
+timeout_mins: 1200

--- a/.kokoro/periodic/long-running-spark4.cfg
+++ b/.kokoro/periodic/long-running-spark4.cfg
@@ -1,0 +1,25 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+# Spark 4.0 requires Java 17, so this job uses the java17 image.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java17"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "long_running-spark4"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}
+
+timeout_mins: 1200

--- a/.kokoro/presubmit/codestyle/build.sh
+++ b/.kokoro/presubmit/codestyle/build.sh
@@ -29,4 +29,4 @@ set -x
 
 cd ${KOKORO_ARTIFACTS_DIR}/github/spark-bigtable-connector
 
-find spark-bigtable_2.12 spark-bigtable_2.13 spark-bigtable-core spark-bigtable-core-it -name "*.java" -type f -exec java -jar  ${KOKORO_GFILE_DIR}/google-java-format-1.7-all-deps.jar --set-exit-if-changed -n {} +
+find spark-bigtable_2.12 spark-bigtable_2.13 spark-bigtable-spark4_2.13 spark-bigtable-core spark-bigtable-core-it -name "*.java" -type f -exec java -jar  ${KOKORO_GFILE_DIR}/google-java-format-1.7-all-deps.jar --set-exit-if-changed -n {} +

--- a/.kokoro/presubmit/java17.cfg
+++ b/.kokoro/presubmit/java17.cfg
@@ -1,0 +1,23 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+# Spark 4.0 requires Java 17, so this presubmit uses the java17 image.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java17"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "presubmit-spark4"
+}
+
+env_vars: {
+  key: "BIGTABLE_PROJECT_ID"
+  value: "autonomous-mote-782"
+}
+
+env_vars: {
+  key: "BIGTABLE_INSTANCE_ID"
+  value: "bigtable-spark-connector"
+}

--- a/README-template.md
+++ b/README-template.md
@@ -130,8 +130,15 @@ The connector supports the following Spark versions:
 
 | Scala version | Spark versions                    | Spark Application Languages                             |
 |---------------|-----------------------------------|---------------------------------------------------------|
+| 2.13          | 4.0.x                             | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 | 2.13          | 3.1.x, 3.2.x, 3.4.x, 3.5.x        | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 | 2.12          | 2.4.8, 3.1.x, 3.2.x, 3.4.x, 3.5.x | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
+
+> **Note:** Spark 4.0.x requires Scala 2.13 and Java 17, and is published as a
+> separate artifact,
+> `com.google.cloud.spark.bigtable:spark-bigtable-spark4_2.13`. The Spark 3.x and
+> 2.4.x connectors (`spark-bigtable_2.13` / `spark-bigtable_2.12`) run on Java 8
+> or 11.
 
 ## Main features
 

--- a/README-template.md
+++ b/README-template.md
@@ -130,11 +130,11 @@ The connector supports the following Spark versions:
 
 | Scala version | Spark versions                    | Spark Application Languages                             |
 |---------------|-----------------------------------|---------------------------------------------------------|
-| 2.13          | 4.0.x                             | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
+| 2.13          | 4.1.x                             | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 | 2.13          | 3.1.x, 3.2.x, 3.4.x, 3.5.x        | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 | 2.12          | 2.4.8, 3.1.x, 3.2.x, 3.4.x, 3.5.x | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 
-> **Note:** Spark 4.0.x requires Scala 2.13 and Java 17, and is published as a
+> **Note:** Spark 4.1.x requires Scala 2.13 and Java 17, and is published as a
 > separate artifact,
 > `com.google.cloud.spark.bigtable:spark-bigtable-spark4_2.13`. The Spark 3.x and
 > 2.4.x connectors (`spark-bigtable_2.13` / `spark-bigtable_2.12`) run on Java 8

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ The connector supports the following Spark versions:
 
 | Scala version | Spark versions                    | Spark Application Languages                             |
 |---------------|-----------------------------------|---------------------------------------------------------|
-| 2.13          | 4.0.x                             | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
+| 2.13          | 4.1.x                             | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 | 2.13          | 3.1.x, 3.2.x, 3.4.x, 3.5.x        | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 | 2.12          | 2.4.8, 3.1.x, 3.2.x, 3.4.x, 3.5.x | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 
-> **Note:** Spark 4.0.x requires Scala 2.13 and Java 17, and is published as a
+> **Note:** Spark 4.1.x requires Scala 2.13 and Java 17, and is published as a
 > separate artifact,
 > `com.google.cloud.spark.bigtable:spark-bigtable-spark4_2.13`. The Spark 3.x and
 > 2.4.x connectors (`spark-bigtable_2.13` / `spark-bigtable_2.12`) run on Java 8

--- a/README.md
+++ b/README.md
@@ -123,8 +123,15 @@ The connector supports the following Spark versions:
 
 | Scala version | Spark versions                    | Spark Application Languages                             |
 |---------------|-----------------------------------|---------------------------------------------------------|
+| 2.13          | 4.0.x                             | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 | 2.13          | 3.1.x, 3.2.x, 3.4.x, 3.5.x        | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
 | 2.12          | 2.4.8, 3.1.x, 3.2.x, 3.4.x, 3.5.x | Java, Scala, PySpark (`.py` files or Jupyter notebooks) |
+
+> **Note:** Spark 4.0.x requires Scala 2.13 and Java 17, and is published as a
+> separate artifact,
+> `com.google.cloud.spark.bigtable:spark-bigtable-spark4_2.13`. The Spark 3.x and
+> 2.4.x connectors (`spark-bigtable_2.13` / `spark-bigtable_2.12`) run on Java 8
+> or 11.
 
 ## Main features
 

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,25 @@
                     <pattern>io.grpc</pattern>
                     <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.grpc</shadedPattern>
                   </relocation>
+                  <!-- Telemetry libraries that gRPC/google-http-client depend on.
+                       These MUST be relocated in lockstep with io.grpc above: they
+                       reference io.grpc.Context, so if they stay in their original
+                       packages while io.grpc is relocated, a host classpath that
+                       ships its own copy (e.g. Databricks bundles io.opencensus)
+                       wins and then fails with NoClassDefFoundError: io/grpc/Context
+                       because the plain io.grpc.Context is nowhere on the classpath. -->
+                  <relocation>
+                    <pattern>io.opencensus</pattern>
+                    <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.opencensus</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.opentelemetry</pattern>
+                    <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.opentelemetry</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.perfmark</pattern>
+                    <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.perfmark</shadedPattern>
+                  </relocation>
                   <relocation>
                     <pattern>com.google</pattern>
                     <shadedPattern>com.google.cloud.spark.bigtable.repackaged.com.google</shadedPattern>

--- a/pom.xml
+++ b/pom.xml
@@ -54,16 +54,20 @@
     <module>spark-bigtable_2.12</module>
     <module>spark-bigtable_2.13</module>
     <module>spark-bigtable-core-it</module>
+    <!-- spark-bigtable-spark4_2.13 is NOT listed here: Spark 4 requires Java 17,
+         so building it under Java 8/11 (e.g. the java11 kokoro job's full-reactor
+         `mvn install`) fails with "invalid target release: 17". It is added to the
+         reactor only by the jdk17 profile below, which auto-activates on JDK 17+. -->
   </modules>
 
   <properties>
     <gpg.skip>true</gpg.skip>
     <nexus.remote.skip>false</nexus.remote.skip>
 
-    <scala.version>2.13.14</scala.version>
+    <scala.version>2.13.17</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <connector.artifact.id>spark-bigtable_2.13</connector.artifact.id>
-    <spark.version>3.5.1</spark.version>
+    <spark.version>3.5.3</spark.version>
     <bigtable.java.version>2.75.1</bigtable.java.version>
     <bigtable.java.emulator.version>0.212.1</bigtable.java.emulator.version>
 
@@ -83,9 +87,365 @@
     <scala-parser-combinators.version>1.1.2</scala-parser-combinators.version>
     <commons-lang.version>2.6</commons-lang.version>
     <openlineage.version>1.22.0</openlineage.version>
+
+    <!-- Dependency versions shared by all connector variant modules. -->
+    <openlineage-entrypoint.version>1.0.0</openlineage-entrypoint.version>
+    <re2j.version>1.8</re2j.version>
+    <upickle.version>4.2.1</upickle.version>
+    <jackson.version>2.15.2</jackson.version>
+
+    <!-- Build-plugin versions (config lives in <pluginManagement> below). -->
+    <scala-maven-plugin.version>4.7.2</scala-maven-plugin.version>
+    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
+    <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
+    <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
+    <license-maven-plugin.version>2.4.0</license-maven-plugin.version>
+    <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
   </properties>
 
+  <!--
+    Versions (and common scope/exclusions) for every dependency used by the
+    connector variant modules. The variant poms declare these dependencies
+    without <version>, inheriting from here. Artifact ids that embed
+    ${scala.binary.version} resolve against each child's own property, so the
+    same entry serves Scala 2.12 and 2.13.
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable</artifactId>
+        <version>${bigtable.java.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
+        <version>${bigtable.java.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.re2j</groupId>
+        <artifactId>re2j</artifactId>
+        <version>${re2j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.lihaoyi</groupId>
+        <artifactId>upickle_${scala.binary.version}</artifactId>
+        <version>${upickle.version}</version>
+      </dependency>
+
+      <!--
+        NOTE: jackson-core and scala-parser-combinators are deliberately NOT
+        managed here. They are Spark-3.x-only pins (see the 3.x variant poms).
+        A <dependencyManagement> entry also overrides *transitive* versions, so
+        pinning jackson-core to the Spark-3.5 value (${jackson.version}) here
+        would drag Spark 4's newer transitive jackson down to it and break the
+        Spark 4 module at runtime (BufferRecycler.releaseToPool NoSuchMethodError).
+        Keeping them as version-bearing direct deps in the 3.x modules only keeps
+        Spark 4 on its own transitive versions.
+      -->
+
+      <!-- Scala -->
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>${scala.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <!-- Spark -->
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-core_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+        <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scalap</artifactId>
+          </exclusion>
+          <!-- exclude log4j v1 transitive dependencies as we use reload4j instead -->
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-sql_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <!-- OpenLineage -->
+      <dependency>
+        <groupId>io.openlineage</groupId>
+        <artifactId>spark-extension-interfaces</artifactId>
+        <version>${openlineage.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.openlineage</groupId>
+        <artifactId>spark-extension-entrypoint</artifactId>
+        <version>${openlineage-entrypoint.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <!-- Test -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-reload4j</artifactId>
+        <version>${slf4j-reload4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest_${scala.binary.version}</artifactId>
+        <version>${scalatest.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-emulator</artifactId>
+        <version>${bigtable.java.emulator.version}</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <!--
+    Full build-plugin configuration shared by all variant modules. Each variant
+    pom lists only the plugin coordinates (no config) and inherits the config
+    below. The one per-variant knob is ${hbase.connectors.scala.dir}, the
+    Scala-version-specific third_party source directory, set in each child.
+  -->
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <version>${scala-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>compile</goal>
+                <goal>testCompile</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-compiler-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>add-source</id>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>../spark-bigtable-core/src/main/scala</source>
+                  <source>../spark-bigtable-core/src/test/java</source>
+                  <!-- Test server infrastructure used in unit/integration tests. -->
+                  <!-- Third-party code kept under third_party/ for licensing compliance. -->
+                  <source>../third_party/hbase-spark-connector/hbase-connectors/src/main/scala/</source>
+                  <!-- SchemaConverters differs by Scala binary version; set per child. -->
+                  <source>${hbase.connectors.scala.dir}</source>
+                  <!-- Included for reciprocal license compliance. -->
+                  <source>${project.build.directory}/sources</source>
+                </sources>
+              </configuration>
+            </execution>
+            <execution>
+              <id>add-test-source</id>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>add-test-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>../spark-bigtable-core/src/test/scala</source>
+                  <source>../third_party/hbase-spark-connector/hbase-connectors/src/test/scala/</source>
+                </sources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven-shade-plugin.version}</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <transformers>
+                  <transformer
+                      implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                  <transformer
+                      implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                    <addHeader>false</addHeader>
+                  </transformer>
+                  <transformer
+                      implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                  </transformer>
+                  <transformer
+                      implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                    <manifestEntries>
+                      <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+                      <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
+                    </manifestEntries>
+                  </transformer>
+                </transformers>
+                <artifactSet>
+                  <excludes>
+                    <exclude>org.slf4j:slf4j-reload4j</exclude>
+                    <exclude>org.slf4j:slf4j-api</exclude>
+                    <exclude>ch.qos.reload4j:reload4j</exclude>
+                  </excludes>
+                </artifactSet>
+                <relocations>
+                  <relocation>
+                    <pattern>io.netty</pattern>
+                    <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.netty</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.grpc</pattern>
+                    <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.grpc</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>com.google</pattern>
+                    <shadedPattern>com.google.cloud.spark.bigtable.repackaged.com.google</shadedPattern>
+                    <excludes>
+                      <exclude>com.google.cloud.spark.bigtable.**</exclude>
+                    </excludes>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.openlineage.spark.shade</pattern>
+                    <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.openlineage.spark.shade</shadedPattern>
+                  </relocation>
+                </relocations>
+              </configuration>
+            </execution>
+          </executions>
+          <configuration>
+            <filters>
+              <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                  <exclude>META-INF/*.SF</exclude>
+                  <exclude>META-INF/*.DSA</exclude>
+                  <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+              </filter>
+            </filters>
+          </configuration>
+        </plugin>
+        <!-- Enable scalatest. -->
+        <plugin>
+          <groupId>org.scalatest</groupId>
+          <artifactId>scalatest-maven-plugin</artifactId>
+          <version>${scalatest-maven-plugin.version}</version>
+          <configuration>
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+            <junitxml>.</junitxml>
+            <filereports>WDF TestSuite.txt</filereports>
+            <runpath>../third_party/hbase-spark-connector/hbase-connectors/src/test</runpath>
+          </configuration>
+          <executions>
+            <execution>
+              <id>test</id>
+              <goals>
+                <goal>test</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>default-cli</id>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>add-third-party</goal>
+              </goals>
+              <configuration>
+                <excludedScopes>test,provided</excludedScopes>
+                <generateBundle>true</generateBundle>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- Include the source codes of dependencies with reciprocal licenses into the JAR. -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${maven-dependency-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>src-dependencies</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>unpack-dependencies</goal>
+              </goals>
+              <configuration>
+                <includeArtifactIds>javax.annotation-api</includeArtifactIds>
+                <classifier>sources</classifier>
+                <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                <outputDirectory>${project.build.directory}/sources</outputDirectory>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <profiles>
+    <!-- Spark 4 requires Java 17. This profile auto-activates on JDK 17+ and adds
+         the Spark 4 module to the reactor, so a full-reactor build only attempts to
+         compile it when the running JDK can actually target 17. On Java 8/11 the
+         module is absent from the reactor entirely (see the <modules> note above),
+         which is what keeps the java11 kokoro job from failing on it. The java17
+         kokoro job (presubmit-spark4) runs on JDK 17, so the module is included. -->
+    <profile>
+      <id>jdk17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <modules>
+        <module>spark-bigtable-spark4_2.13</module>
+      </modules>
+    </profile>
     <profile>
       <id>release</id>
       <properties>

--- a/spark-bigtable-core-it/pom.xml
+++ b/spark-bigtable-core-it/pom.xml
@@ -116,6 +116,38 @@
   </build>
 
   <profiles>
+    <!-- This module is Java-only integration tests, built against one connector
+         variant at a time selected by -Dscala.binary.version (kokoro passes only
+         the binary version, never the full scala.version). The parent centralizes
+         scala-library's version as ${scala.version}, whose default is 2.13.x, so
+         without these profiles a 2.12 build would drag in scala-library 2.13.x and
+         fail at runtime (e.g. NoClassDefFoundError: scala/Serializable in the
+         forked Failsafe JVM). Keep scala.version in lock-step with the binary
+         version so the resolved scala-library matches the connector variant. -->
+    <profile>
+      <id>scala-2.12</id>
+      <activation>
+        <property>
+          <name>scala.binary.version</name>
+          <value>2.12</value>
+        </property>
+      </activation>
+      <properties>
+        <scala.version>2.12.18</scala.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>scala-2.13</id>
+      <activation>
+        <property>
+          <name>scala.binary.version</name>
+          <value>2.13</value>
+        </property>
+      </activation>
+      <properties>
+        <scala.version>2.13.17</scala.version>
+      </properties>
+    </profile>
     <profile>
       <id>integration</id>
       <activation>

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/BigtableTableScanRDDTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/BigtableTableScanRDDTest.scala
@@ -26,7 +26,7 @@ import com.google.cloud.spark.bigtable.filters.RowKeyWrapper
 import com.google.common.collect.{Range, RangeSet, TreeRangeSet}
 import com.google.protobuf.ByteString
 import org.apache.spark.sql.{SQLContext, SparkSession}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.SparkConf
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
@@ -48,23 +48,20 @@ class BigtableTableScanRDDTest
 
   var fakeCustomDataService: FakeCustomDataService = _
   var emulatorPort: String = _
-  @transient var sc: SparkContext = _
   var sqlContext: SQLContext = _
   var rdd: BigtableTableScanRDD = _
 
   override def beforeAll(): Unit = {
     val sparkConf = new SparkConf
     val spark = SparkSession.builder().master("local").appName("test").config(sparkConf).getOrCreate()
-    sc = spark.sparkContext
     sqlContext = spark.sqlContext
   }
 
   override def afterAll(): Unit = {
-    sc.stop()
-    // Clear the active/default SparkSession so a later suite in the same JVM
-    // gets a fresh session that honors its own SparkConf via getOrCreate().
-    SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+    // Stops the SparkContext and clears the active/default SparkSession, so a
+    // later suite in the same JVM gets a fresh session that honors its own
+    // SparkConf via getOrCreate().
+    sqlContext.sparkSession.stop()
   }
 
   override def beforeEach(): Unit = {

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/BigtableTableScanRDDTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/BigtableTableScanRDDTest.scala
@@ -25,7 +25,7 @@ import com.google.cloud.spark.bigtable.fakeserver.{FakeCustomDataService, FakeSe
 import com.google.cloud.spark.bigtable.filters.RowKeyWrapper
 import com.google.common.collect.{Range, RangeSet, TreeRangeSet}
 import com.google.protobuf.ByteString
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -54,12 +54,17 @@ class BigtableTableScanRDDTest
 
   override def beforeAll(): Unit = {
     val sparkConf = new SparkConf
-    sc = new SparkContext("local", "test", sparkConf)
-    sqlContext = new SQLContext(sc)
+    val spark = SparkSession.builder().master("local").appName("test").config(sparkConf).getOrCreate()
+    sc = spark.sparkContext
+    sqlContext = spark.sqlContext
   }
 
   override def afterAll(): Unit = {
     sc.stop()
+    // Clear the active/default SparkSession so a later suite in the same JVM
+    // gets a fresh session that honors its own SparkConf via getOrCreate().
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
   }
 
   override def beforeEach(): Unit = {

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/filters/SparkSqlFilterAdapterTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/filters/SparkSqlFilterAdapterTest.scala
@@ -21,7 +21,7 @@ import com.google.cloud.spark.bigtable.datasources._
 import com.google.common.collect.RangeSet
 import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.apache.spark.sql.sources.{And, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Not, Or, StringStartsWith}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.SparkConf
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
@@ -57,22 +57,19 @@ class SparkSqlFilterAdapterTest
        |}
        |}""".stripMargin
 
-  @transient var sc: SparkContext = _
   var sqlContext: SQLContext = _
 
   override def beforeAll(): Unit = {
     val sparkConf = new SparkConf
     val spark = SparkSession.builder().master("local").appName("test").config(sparkConf).getOrCreate()
-    sc = spark.sparkContext
     sqlContext = spark.sqlContext
   }
 
   override def afterAll(): Unit = {
-    sc.stop()
-    // Clear the active/default SparkSession so a later suite in the same JVM
-    // gets a fresh session that honors its own SparkConf via getOrCreate().
-    SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+    // Stops the SparkContext and clears the active/default SparkSession, so a
+    // later suite in the same JVM gets a fresh session that honors its own
+    // SparkConf via getOrCreate().
+    sqlContext.sparkSession.stop()
   }
 
   // Should be converted to

--- a/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/filters/SparkSqlFilterAdapterTest.scala
+++ b/spark-bigtable-core/src/test/scala/com/google/cloud/spark/bigtable/filters/SparkSqlFilterAdapterTest.scala
@@ -19,7 +19,7 @@ package com.google.cloud.spark.bigtable.filters
 import com.google.cloud.spark.bigtable.BigtableRelation
 import com.google.cloud.spark.bigtable.datasources._
 import com.google.common.collect.RangeSet
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.apache.spark.sql.sources.{And, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, Not, Or, StringStartsWith}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.funsuite.AnyFunSuite
@@ -62,12 +62,17 @@ class SparkSqlFilterAdapterTest
 
   override def beforeAll(): Unit = {
     val sparkConf = new SparkConf
-    sc = new SparkContext("local", "test", sparkConf)
-    sqlContext = new SQLContext(sc)
+    val spark = SparkSession.builder().master("local").appName("test").config(sparkConf).getOrCreate()
+    sc = spark.sparkContext
+    sqlContext = spark.sqlContext
   }
 
   override def afterAll(): Unit = {
     sc.stop()
+    // Clear the active/default SparkSession so a later suite in the same JVM
+    // gets a fresh session that honors its own SparkConf via getOrCreate().
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
   }
 
   // Should be converted to

--- a/spark-bigtable-spark4_2.13/pom.xml
+++ b/spark-bigtable-spark4_2.13/pom.xml
@@ -30,14 +30,14 @@
   <name>Google Bigtable - Apache Spark 4 Connector for Scala 2.13</name>
   <version>0.9.1</version> <!-- ${NEXT_VERSION_FLAG} -->
 
-  <!-- Variant coordinates: Spark 4.0.x / Scala 2.13 (Spark 4 dropped Scala 2.12
+  <!-- Variant coordinates: Spark 4.1.x / Scala 2.13 (Spark 4 dropped Scala 2.12
        and log4j v1). Everything else is inherited from the parent. Unlike the
        Spark 3.x variants, this module does NOT need jackson-core or
        scala-parser-combinators. -->
   <properties>
     <scala.version>2.13.17</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
-    <spark.version>4.0.1</spark.version>
+    <spark.version>4.1.2</spark.version>
     <hbase.connectors.scala.dir>../third_party/hbase-spark-connector/hbase-connectors-scala2.13/src/main/scala/</hbase.connectors.scala.dir>
     <!-- Spark 4 requires Java 17 to compile and run. Override the parent's
          1.8 compiler targets so this module compiles for Java 17 (and the

--- a/spark-bigtable-spark4_2.13/pom.xml
+++ b/spark-bigtable-spark4_2.13/pom.xml
@@ -26,17 +26,24 @@
   </parent>
 
   <groupId>com.google.cloud.spark.bigtable</groupId>
-  <artifactId>spark-bigtable_2.13</artifactId>
-  <name>Google Bigtable - Apache Spark Connector for Scala 2.13</name>
+  <artifactId>spark-bigtable-spark4_2.13</artifactId>
+  <name>Google Bigtable - Apache Spark 4 Connector for Scala 2.13</name>
   <version>0.9.1</version> <!-- ${NEXT_VERSION_FLAG} -->
 
-  <!-- Variant coordinates: Spark 3.5.x / Scala 2.13. Everything else
-       (dependency versions, plugin config) is inherited from the parent. -->
+  <!-- Variant coordinates: Spark 4.0.x / Scala 2.13 (Spark 4 dropped Scala 2.12
+       and log4j v1). Everything else is inherited from the parent. Unlike the
+       Spark 3.x variants, this module does NOT need jackson-core or
+       scala-parser-combinators. -->
   <properties>
     <scala.version>2.13.17</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
-    <spark.version>3.5.3</spark.version>
+    <spark.version>4.0.1</spark.version>
     <hbase.connectors.scala.dir>../third_party/hbase-spark-connector/hbase-connectors-scala2.13/src/main/scala/</hbase.connectors.scala.dir>
+    <!-- Spark 4 requires Java 17 to compile and run. Override the parent's
+         1.8 compiler targets so this module compiles for Java 17 (and the
+         shaded JAR manifest's X-Compile-*-JDK reflect 17). -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -57,27 +64,13 @@
       <artifactId>upickle_${scala.binary.version}</artifactId>
     </dependency>
 
-    <!-- To fix the "NoClassDefFoundError: com/fasterxml/jackson/core/exc/StreamConstraintsException" error with Spark 3.5-->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-
-    <!-- To fix the "NoClassDefFoundError: scala/util/parsing/json/JSON$" error with Spark 3.4. -->
-    <dependency>
-      <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
-      <version>${scala-parser-combinators.version}</version>
-    </dependency>
-
     <!-- Scala dependencies -->
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
     </dependency>
 
-    <!-- Spark dependencies -->
+    <!-- Spark 4 dependencies -->
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
@@ -87,10 +80,10 @@
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-reload4j</artifactId>
-    </dependency>
+    <!-- No slf4j-reload4j here: Spark 4 dropped Log4j 1.x and its spark-core
+         transitively provides the Log4j 2 SLF4J binding (log4j-slf4j2-impl).
+         Adding reload4j (a Log4j 1.x binding) would create a duplicate SLF4J
+         binding and classpath conflicts. -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/spark-bigtable_2.12/pom.xml
+++ b/spark-bigtable_2.12/pom.xml
@@ -30,42 +30,38 @@
   <name>Google Bigtable - Apache Spark Connector</name>
   <version>0.9.1</version> <!-- ${NEXT_VERSION_FLAG} -->
 
+  <!-- Variant coordinates: Spark 3.5.x / Scala 2.12. Everything else
+       (dependency versions, plugin config) is inherited from the parent. -->
   <properties>
     <scala.version>2.12.18</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>3.5.1</spark.version>
-    <re2j.version>1.8</re2j.version>
-    <upickle.version>4.2.1</upickle.version>
+    <spark.version>3.5.3</spark.version>
+    <hbase.connectors.scala.dir>../third_party/hbase-spark-connector/hbase-connectors-scala2.12/src/main/scala/</hbase.connectors.scala.dir>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
-      <version>${bigtable.java.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
-      <version>${bigtable.java.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.re2j</groupId>
       <artifactId>re2j</artifactId>
-      <version>${re2j.version}</version>
     </dependency>
-
     <dependency>
       <groupId>com.lihaoyi</groupId>
       <artifactId>upickle_${scala.binary.version}</artifactId>
-      <version>${upickle.version}</version>
     </dependency>
 
     <!-- To fix the "NoClassDefFoundError: com/fasterxml/jackson/core/exc/StreamConstraintsException" error with Spark 3.5-->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.2</version>
+      <version>${jackson.version}</version>
     </dependency>
 
     <!-- To fix the "NoClassDefFoundError: scala/util/parsing/json/JSON$" error with Spark 3.4. -->
@@ -79,82 +75,42 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- Spark dependencies -->
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <version>${spark.version}</version>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scalap</artifactId>
-        </exclusion>
-        <!-- exclude log4j v1 transitive dependencies as we use reload4j instead -->
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
-      <version>${spark.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
-      <version>${slf4j-reload4j.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>${scalatest.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>io.openlineage</groupId>
       <artifactId>spark-extension-interfaces</artifactId>
-      <version>${openlineage.version}</version>
     </dependency>
     <dependency>
       <groupId>io.openlineage</groupId>
       <artifactId>spark-extension-entrypoint</artifactId>
-      <version>1.0.0</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable-emulator</artifactId>
-      <version>${bigtable.java.emulator.version}</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -164,203 +120,35 @@
         <directory>../spark-bigtable-core/src/main/resources</directory>
       </resource>
     </resources>
+    <!-- Config for all of these is inherited from the parent's <pluginManagement>. -->
     <plugins>
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.7.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>compile</goal>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.3.0</version>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>../spark-bigtable-core/src/main/scala</source>
-                <source>../spark-bigtable-core/src/test/java</source>
-                <!-- This directory only contains test server infrastructure used in unit/integration
-                      tests, so we specify it as a source. -->
-                <!-- We need to put third-party code inside the `third_party` directory
-                      for licensing compliance, including them in the project here. -->
-                <source>../third_party/hbase-spark-connector/hbase-connectors/src/main/scala/</source>
-                <!-- We need to put third-party code inside the `third_party` directory
-                      for licensing compliance, including them in the project here.
-                      This is included to get the SchemaConverters class(it has different syntax for scala 2.12)-->
-                <source>
-                  ../third_party/hbase-spark-connector/hbase-connectors-scala2.12/src/main/scala/
-                </source>
-                <!-- Included for reciprocal license compliance.-->
-                <source>${project.build.directory}/sources</source>
-              </sources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-test-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>../spark-bigtable-core/src/test/scala</source>
-                <source>../third_party/hbase-spark-connector/hbase-connectors/src/test/scala/</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.4.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <transformers>
-                <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                  <addHeader>false</addHeader>
-                </transformer>
-                <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
-                </transformer>
-                <transformer
-                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <manifestEntries>
-                    <Main-Class>${app.main.class}</Main-Class>
-                    <X-Compile-Source-JDK>${maven.compile.source}</X-Compile-Source-JDK>
-                    <X-Compile-Target-JDK>${maven.compile.target}</X-Compile-Target-JDK>
-                  </manifestEntries>
-                </transformer>
-              </transformers>
-              <artifactSet>
-                <excludes>
-                  <exclude>org.slf4j:slf4j-reload4j</exclude>
-                  <exclude>org.slf4j:slf4j-api</exclude>
-                  <exclude>ch.qos.reload4j:reload4j</exclude>
-                </excludes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>io.grpc</pattern>
-                  <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.grpc</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.google</pattern>
-                  <shadedPattern>com.google.cloud.spark.bigtable.repackaged.com.google</shadedPattern>
-                  <excludes>
-                    <exclude>com.google.cloud.spark.bigtable.**</exclude>
-                  </excludes>
-                </relocation>
-                <relocation>
-                  <pattern>io.openlineage.spark.shade</pattern>
-                  <shadedPattern>com.google.cloud.spark.bigtable.repackaged.io.openlineage.spark.shade</shadedPattern>
-                </relocation>
-              </relocations>
-            </configuration>
-          </execution>
-        </executions>
-        <configuration>
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
-              </excludes>
-            </filter>
-          </filters>
-        </configuration>
       </plugin>
-      <!-- Enable scalatest. -->
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>2.2.0</version>
-        <configuration>
-          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-          <junitxml>.</junitxml>
-          <filereports>WDF TestSuite.txt</filereports>
-          <runpath>../third_party/hbase-spark-connector/hbase-connectors/src/test</runpath>
-        </configuration>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.4.0</version>
-        <executions>
-          <execution>
-            <id>default-cli</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>add-third-party</goal>
-            </goals>
-            <configuration>
-              <excludedScopes>test,provided</excludedScopes>
-              <generateBundle>true</generateBundle>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
-      <!-- Include the source codes of dependencies with reciprocal licenses into the JAR. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.0</version>
-        <executions>
-          <execution>
-            <id>src-dependencies</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <configuration>
-              <includeArtifactIds>javax.annotation-api</includeArtifactIds>
-              <classifier>sources</classifier>
-              <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
-              <outputDirectory>${project.build.directory}/sources</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/datasources/BigtableTableCatalog.scala
+++ b/third_party/hbase-spark-connector/hbase-connectors/src/main/scala/com/google/cloud/spark/bigtable/datasources/BigtableTableCatalog.scala
@@ -25,7 +25,6 @@ import org.apache.yetus.audience.InterfaceAudience
 
 import java.sql.{Date, Timestamp}
 import scala.collection.mutable
-import scala.util.parsing.json.JSON
 
 // As we finalize the encoding of different types, we add support for them.
 object SupportedDataTypes {

--- a/third_party/hbase-spark-connector/hbase-connectors/src/test/scala/com/google/cloud/spark/bigtable/RowFilterLogicTest.scala
+++ b/third_party/hbase-spark-connector/hbase-connectors/src/test/scala/com/google/cloud/spark/bigtable/RowFilterLogicTest.scala
@@ -119,11 +119,10 @@ class RowFilterLogicTest
   override def afterAll() {
     emulator.stop()
 
-    sc.stop()
-    // Clear the active/default SparkSession so a later suite in the same JVM
-    // gets a fresh session that honors its own SparkConf via getOrCreate().
-    SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+    // Stops the SparkContext and clears the active/default SparkSession, so a
+    // later suite in the same JVM gets a fresh session that honors its own
+    // SparkConf via getOrCreate().
+    sqlContext.sparkSession.stop()
   }
 
   /** A example of query three fields and also only using rowkey points for the filter

--- a/third_party/hbase-spark-connector/hbase-connectors/src/test/scala/com/google/cloud/spark/bigtable/RowFilterLogicTest.scala
+++ b/third_party/hbase-spark-connector/hbase-connectors/src/test/scala/com/google/cloud/spark/bigtable/RowFilterLogicTest.scala
@@ -26,7 +26,7 @@ import com.google.protobuf.ByteString
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.{DataFrame, SQLContext, SparkSession}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -65,8 +65,9 @@ class RowFilterLogicTest
     logInfo(" - created table")
 
     val sparkConf = new SparkConf
-
-    sc = new SparkContext("local", "test", sparkConf)
+    val spark = SparkSession.builder().master("local").appName("test").config(sparkConf).getOrCreate()
+    sc = spark.sparkContext
+    sqlContext = spark.sqlContext
 
     fillTables()
 
@@ -79,8 +80,6 @@ class RowFilterLogicTest
               |"B_FIELD":{"cf":"c", "col":"b", "type":"string"}
             |}
           |}""".stripMargin
-
-    sqlContext = new SQLContext(sc)
 
     df = sqlContext.load(
       "bigtable",
@@ -121,6 +120,10 @@ class RowFilterLogicTest
     emulator.stop()
 
     sc.stop()
+    // Clear the active/default SparkSession so a later suite in the same JVM
+    // gets a fresh session that honors its own SparkConf via getOrCreate().
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
   }
 
   /** A example of query three fields and also only using rowkey points for the filter


### PR DESCRIPTION
…ze build config

Version sync + new Spark 4 module:
- Bump Spark/Scala versions in sync with Dataproc/Managed Spark.
- Add spark-bigtable-spark4_2.13

Centralize dependency and plugin management in the parent pom:
- Hoist <dependencyManagement> and <build><pluginManagement> into the parent so the variant modules declare only coordinates and inherit versions/config, mirroring the spark-bigquery-connector layout.
- Thin spark-bigtable_2.12, spark-bigtable_2.13, and spark-bigtable-spark4_2.13 to coordinates-only poms.
- Keep jackson-core and scala-parser-combinators as direct, version-pinned deps in the Spark 3.x modules (NOT in dependencyManagement), so managing them does not drag Spark 4.0.1's newer transitive jackson down and break it.

Wire Spark 4 into .kokoro:
- build.sh: run_unit_tests and run_bigtable_spark_tests accept an optional module/artifact override; new presubmit-spark4 job exports the Java 17 --add-opens set via JAVA_TOOL_OPTIONS (so it reaches the forked scalatest JVMs) and runs the spark4 unit + integration tests.
- presubmit/java17.cfg: new presubmit on the java17 trampoline image.
- presubmit/codestyle/build.sh: format-check the spark4 module too.