### PR TITLE
fix: update apt package lists before installing cbt CLI

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -46,8 +46,46 @@ fi
 RETURN_CODE=0
 set +e
 
-echo "Installing the cbt CLI command."
-apt install -y google-cloud-sdk-cbt
+# Ensure cbt is in PATH if it's installed alongside gcloud but not in PATH
+if ! command -v cbt &> /dev/null && command -v gcloud &> /dev/null; then
+  GCLOUD_PATH=$(readlink -f "$(command -v gcloud)")
+  GCLOUD_BIN_DIR=$(dirname "${GCLOUD_PATH}")
+  if [[ -x "${GCLOUD_BIN_DIR}/cbt" ]]; then
+    export PATH="${PATH}:${GCLOUD_BIN_DIR}"
+  fi
+fi
+
+# Install cbt if it is not present
+if ! command -v cbt &> /dev/null; then
+  echo "Installing the cbt CLI command."
+  if command -v gcloud &> /dev/null && gcloud components install cbt --quiet 2>/dev/null; then
+    echo "cbt installed via gcloud components."
+  else
+    echo "Installing cbt via apt..."
+    if command -v sudo &> /dev/null; then
+      sudo apt-get update -y || true
+      sudo apt-get install -y google-cloud-cli-cbt || sudo apt-get install -y google-cloud-sdk-cbt
+    else
+      apt-get update -y || true
+      apt-get install -y google-cloud-cli-cbt || apt-get install -y google-cloud-sdk-cbt
+    fi
+  fi
+
+  # Ensure the newly installed cbt is in PATH
+  if ! command -v cbt &> /dev/null && command -v gcloud &> /dev/null; then
+    GCLOUD_PATH=$(readlink -f "$(command -v gcloud)")
+    GCLOUD_BIN_DIR=$(dirname "${GCLOUD_PATH}")
+    if [[ -x "${GCLOUD_BIN_DIR}/cbt" ]]; then
+      export PATH="${PATH}:${GCLOUD_BIN_DIR}"
+    fi
+  fi
+fi
+
+if command -v cbt &> /dev/null; then
+  echo "cbt CLI is available at $(command -v cbt)."
+else
+  echo "WARNING: cbt CLI could not be installed."
+fi
 
 run_unit_tests() {
     SCALA_VERSION=$1


### PR DESCRIPTION
## Description
Update cbt installation in `.kokoro/build.sh` to update apt package lists before installing, and support installing via gcloud components or modern `google-cloud-cli-cbt` package.

## Root Cause
Previously, `apt install -y google-cloud-sdk-cbt` was called directly without running `apt-get update`. In older base images (such as `gcr.io/cloud-devrel-kokoro-resources/java11`), the cached package index referenced older package versions (e.g. `google-cloud-cli-cbt 514.0.0-0`) that had since been replaced and removed from `packages.cloud.google.com/apt`, causing `404 Not Found` errors:

```
Err:1 http://packages.cloud.google.com/apt cloud-sdk/main amd64 google-cloud-cli-cbt amd64 514.0.0-0 404 Not Found
E: Failed to fetch http://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli-cbt_514.0.0-0_amd64_03a51de04d51cdd23f7f8cb7ca02644d.deb 404 Not Found
```

Because `set +e` was active, the build continued without `cbt` installed, which caused subsequent tests requiring `cbt` (such as `fuzz`) to fail with `cbt: command not found` when attempting to create/delete test tables.

## Solution
1. Check if `cbt` is already in PATH or in the same directory as `gcloud`.
2. If not found, attempt `gcloud components install cbt --quiet`.
3. If that fails, run `apt-get update -y || true` followed by `apt-get install -y google-cloud-cli-cbt || apt-get install -y google-cloud-sdk-cbt` (supporting `sudo` if present).
4. Verify and log `cbt` availability.